### PR TITLE
feat(2052): Upgrade amqp package, add rabbitmq connect options and remove unused exchange type var

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -261,3 +261,5 @@ scheduler:
         exchange: RABBITMQ_EXCHANGE
         # Virtual host to connect to
         vhost: RABBITMQ_VHOST
+        # Connection options
+        connectOptions: RABBITMQ_CONNECT_OPTIONS

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -194,3 +194,5 @@ scheduler:
     exchange: build
     # Virtual host to connect to
     vhost: /screwdriver
+    # Connect Options
+    connectOptions: { json: true, heartbeatIntervalInSeconds: 20, reconnectTimeInSeconds: 30 }

--- a/config/rabbitmq.js
+++ b/config/rabbitmq.js
@@ -3,7 +3,7 @@
 const config = require('config');
 
 const rabbitmqConfig = config.get('scheduler').rabbitmq;
-const { protocol, username, password, host, port, exchange, exchangeType, vhost } = rabbitmqConfig;
+const { protocol, username, password, host, port, exchange, vhost, connectOptions } = rabbitmqConfig;
 const amqpURI = `${protocol}://${username}:${password}@${host}:${port}${vhost}`;
 const schedulerMode = config.get('scheduler').enabled;
 
@@ -17,7 +17,7 @@ function getConfig() {
         schedulerMode,
         amqpURI,
         exchange,
-        exchangeType
+        connectOptions
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@hapi/hapi": "^19.1.1",
     "@hapi/hoek": "^9.0.4",
     "@hapi/joi": "^17.1.1",
-    "amqp-connection-manager": "^2.3.0",
+    "amqp-connection-manager": "^3.2.0",
     "amqplib": "^0.5.3",
     "blipp": "^4.0.1",
     "circuit-fuses": "^4.0.0",

--- a/plugins/worker/lib/jobs.js
+++ b/plugins/worker/lib/jobs.js
@@ -11,7 +11,7 @@ const { Filter } = require('./Filter');
 const blockedByConfig = config.get('plugins').blockedBy;
 const { connectionDetails, queuePrefix, runningJobsPrefix, waitingJobsPrefix } = require('../../../config/redis');
 const rabbitmqConf = require('../../../config/rabbitmq');
-const { amqpURI, exchange } = rabbitmqConf.getConfig();
+const { amqpURI, exchange, connectOptions } = rabbitmqConf.getConfig();
 
 const RETRY_LIMIT = 3;
 // This is in milliseconds, reference: https://github.com/taskrabbit/node-resque/blob/master/lib/plugins/Retry.js#L12
@@ -67,7 +67,7 @@ function getRabbitmqConn() {
         return rabbitmqConn;
     }
 
-    rabbitmqConn = amqp.connect([amqpURI], { json: true });
+    rabbitmqConn = amqp.connect([amqpURI], connectOptions);
     logger.info('Creating new rabbitmq connection.');
 
     rabbitmqConn.on('connect', () => logger.info('Connected to rabbitmq!'));

--- a/test/plugins/worker/lib/filter.test.js
+++ b/test/plugins/worker/lib/filter.test.js
@@ -58,8 +58,7 @@ describe('Plugin Test', () => {
         mockRabbitmqConfigObj = {
             schedulerMode: false,
             amqpURI: 'amqp://localhost:5672',
-            exchange: 'build',
-            exchangeType: 'topic'
+            exchange: 'build'
         };
 
         mockRabbitmqConfig = {


### PR DESCRIPTION
## Context

At times the connection to rabbitmq server is lost.

## Objective

This PR upgrades amqp-connection-manager package version from v2.3.0 [Nov 20, 2018] to v3.2.0 [Jan, 20, 2020] and enable rabbitmq heartbeat check and reconnect interval via connect options config instead.

## References

[screwdriver-cd/screwdriver#2052](https://github.com/screwdriver-cd/screwdriver/issues/2052)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
