### PR TITLE
fix: Prevent multiple build update in case of frozen jobs

### DIFF
--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -2,7 +2,9 @@
 
 const request = require('request');
 const requestretry = require('requestretry');
+const logger = require('screwdriver-logger');
 const { queuePrefix } = require('../config/redis');
+
 const RETRY_LIMIT = 3;
 const RETRY_DELAY = 5;
 
@@ -35,6 +37,8 @@ function formatOptions(method, uri, token, body, retryStrategyFn) {
             retryDelay: RETRY_DELAY * 1000 // in ms
         });
     }
+
+    logger.info(`${options.method} ${options.uri}`);
 
     return options;
 }
@@ -176,7 +180,11 @@ async function getPipelineAdmin(token, apiUri, pipelineId, retryStrategyFn) {
                         return resolve(res.body);
                     }
                     if (res.statusCode !== 200) {
-                        return reject(new Error(`No pipeline admin found with ${res.statusCode} code`));
+                        return reject(
+                            new Error(
+                                `No pipeline admin found with ${res.statusCode} code and ${JSON.stringify(res.body)}`
+                            )
+                        );
                     }
                 }
 
@@ -203,11 +211,13 @@ async function updateBuild(updateConfig, retryStrategyFn) {
             (err, res) => {
                 if (!err) {
                     if (res.statusCode === 200) {
-                        return resolve(res);
+                        return resolve(res.body);
                     }
 
                     if (res.statusCode !== 200) {
-                        return reject(new Error(`Build not updated with ${res.statusCode} code`));
+                        return reject(
+                            new Error(`Build not updated with ${res.statusCode}code and ${JSON.stringify(res.body)}`)
+                        );
                     }
                 }
 

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -279,7 +279,7 @@ async function start(executor, config) {
 
     // Check freeze window
     if (currentTime.getTime() > origTime.getTime() && !forceStart) {
-        let payload = {
+        const payload = {
             status: 'FROZEN',
             statusMessage: `Blocked by freeze window, re-enqueued to ${currentTime}`
         };

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -279,7 +279,7 @@ async function start(executor, config) {
 
     // Check freeze window
     if (currentTime.getTime() > origTime.getTime() && !forceStart) {
-        const payload = {
+        let payload = {
             status: 'FROZEN',
             statusMessage: `Blocked by freeze window, re-enqueued to ${currentTime}`
         };


### PR DESCRIPTION
## Context

In case of frozen builds update build was called 2 times once for status and once for stats which resulted in 403 on second update.

## Objective

This PR merges the build update for stats and status in case of frozen builds and fixes the 403 issue

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
