### PR TITLE
feat: Implement lock check in processing build timeouts

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -55,10 +55,9 @@ module.exports = class ExecutorQueue {
                 this.redis[funcName](...args),
             breakerOptions
         );
-        this.requestRetryStrategy = (err, response) =>
-            !!err || (response.statusCode !== 201 && response.statusCode !== 200);
+        this.requestRetryStrategy = (err, response) => !!err || Math.floor(response.statusCode / 100) !== 2;
         this.requestRetryStrategyPostEvent = (err, response) =>
-            !!err || (response.statusCode !== 201 && response.statusCode !== 200 && response.statusCode !== 404); // postEvent can return 404 if no job to start
+            !!err || (Math.floor(response.statusCode / 100) !== 2 && response.statusCode !== 404); // postEvent can return 404 if no job to start
         this.fuseBox = new FuseBox();
         this.fuseBox.addFuse(this.queueBreaker);
         this.fuseBox.addFuse(this.redisBreaker);

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -11,7 +11,7 @@ const AuthJWT = require('hapi-auth-jwt2');
  */
 async function registerResourcePlugins(server, config) {
     try {
-        const plugins = ['worker', 'queue', 'status', 'auth', 'shutdown'];
+        const plugins = ['worker', 'queue', 'status', 'auth', 'shutdown', 'logging'];
 
         return plugins.map(pluginName =>
             server.register({

--- a/lib/server.js
+++ b/lib/server.js
@@ -71,14 +71,6 @@ module.exports = async config => {
         // Write prettier errors
         server.ext('onPreResponse', prettyPrintErrors);
 
-        server.events.on('response', request => {
-            logger.info(
-                `${request.info.remoteAddress}: ${request.method.toUpperCase()} ${request.path} --> ${
-                    request.response.statusCode
-                }`
-            );
-        });
-
         await registerPlugins(server, config);
 
         logger.info('Server running on %s', server.info.uri);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.0",
+    "@hapi/good": "^9.0.0",
+    "@hapi/good-console": "^9.0.0",
+    "@hapi/good-squeeze": "^6.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/hoek": "^9.0.4",
     "@hapi/joi": "^17.1.1",
@@ -23,6 +26,7 @@
     "jsonwebtoken": "^8.5.1",
     "laabr": "^6.0.1",
     "node-resque": "^5.5.3",
+    "redlock": "^4.1.0",
     "request": "^2.88.0",
     "requestretry": "^3.1.0",
     "screwdriver-data-schema": "^19.6.1",

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -151,6 +151,7 @@ async function createBuildEvent(apiUri, token, buildEvent, retryStrategyFn) {
     return new Promise((resolve, reject) => {
         requestretry(formatOptions('POST', `${apiUri}/v4/events`, token, buildEvent, retryStrategyFn), (err, res) => {
             if (!err) {
+                logger.info(res.statusCode)
                 if (res.statusCode === 201) {
                     return resolve(res);
                 }

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -151,11 +151,19 @@ async function createBuildEvent(apiUri, token, buildEvent, retryStrategyFn) {
     return new Promise((resolve, reject) => {
         requestretry(formatOptions('POST', `${apiUri}/v4/events`, token, buildEvent, retryStrategyFn), (err, res) => {
             if (!err) {
-                logger.info(res.statusCode)
+                logger.info(
+                    `POST /v4/events/${buildEvent.buildId} completed with attempts, ${res.statusCode}, ${res.attempts}`
+                );
                 if (res.statusCode === 201) {
                     return resolve(res);
                 }
                 if (res.statusCode !== 201) {
+                    logger.info(
+                        `POST /v4/events/${buildEvent.buildId} returned non 201, ${res.statusCode}, ${JSON.stringify(
+                            res.body
+                        )}`
+                    );
+
                     return reject(JSON.stringify(res.body));
                 }
             }
@@ -177,6 +185,9 @@ async function getPipelineAdmin(token, apiUri, pipelineId, retryStrategyFn) {
             formatOptions('GET', `${apiUri}/v4/pipelines/${pipelineId}/admin`, token, undefined, retryStrategyFn),
             (err, res) => {
                 if (!err) {
+                    logger.info(
+                        `POST /v4/pipelines/${pipelineId}/admin completed with attempts, ${res.statusCode}, ${res.attempts}`
+                    );
                     if (res.statusCode === 200) {
                         return resolve(res.body);
                     }
@@ -211,6 +222,9 @@ async function updateBuild(updateConfig, retryStrategyFn) {
             formatOptions('PUT', `${apiUri}/v4/builds/${buildId}`, token, payload, retryStrategyFn),
             (err, res) => {
                 if (!err) {
+                    logger.info(
+                        `PUT /v4/builds/${buildId} completed with attempts, ${res.statusCode}, ${res.attempts}`
+                    );
                     if (res.statusCode === 200) {
                         return resolve(res.body);
                     }

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -157,15 +157,13 @@ async function createBuildEvent(apiUri, token, buildEvent, retryStrategyFn) {
                 if (res.statusCode === 201) {
                     return resolve(res);
                 }
-                if (res.statusCode !== 201) {
-                    logger.info(
-                        `POST /v4/events/${buildEvent.buildId} returned non 201, ${res.statusCode}, ${JSON.stringify(
-                            res.body
-                        )}`
-                    );
+                logger.info(
+                    `POST /v4/events/${buildEvent.buildId} returned non 201, ${res.statusCode}, ${JSON.stringify(
+                        res.body
+                    )}`
+                );
 
-                    return reject(JSON.stringify(res.body));
-                }
+                return res.statusCode === 200 ? resolve(JSON.stringify(res.body)) : reject(JSON.stringify(res.body));
             }
 
             return reject(err);

--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const good = require('@hapi/good');
+
+/**
+ * Hapi interface for plugin to set up request, response, error logging
+ * @method register
+ * @param  {Hapi.Server}    server
+ */
+const loggingPlugin = {
+    name: 'logging',
+    async register(server) {
+        server.register({
+            plugin: good,
+            options: {
+                ops: {
+                    interval: 1000
+                },
+                reporters: {
+                    myConsoleReporter: [
+                        {
+                            module: '@hapi/good-squeeze',
+                            name: 'Squeeze',
+                            args: [{ error: '*', log: '*', response: '*', request: '*' }]
+                        },
+                        {
+                            module: '@hapi/good-console'
+                        },
+                        'stdout'
+                    ]
+                }
+            }
+        });
+    }
+};
+
+module.exports = loggingPlugin;

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -66,7 +66,7 @@ async function postBuildEvent(executor, eventConfig) {
                 `POST event for pipeline failed as no admin found: ${pipelineId}:${job.name}:${job.id}:${buildId}`
             );
 
-            throw new Error(`Pipelne admin not found, cannot process build ${buildId}`);
+            throw new Error(`Pipeline admin not found, cannot process build ${buildId}`);
         }
     } catch (err) {
         logger.error(`Error in post build event function ${buildId} ${err}`);

--- a/plugins/status.js
+++ b/plugins/status.js
@@ -6,10 +6,7 @@ const schema = require('screwdriver-data-schema');
  * Hapi interface for plugin to set up status endpoint (see Hapi docs)
  * @method register
  * @param  {Hapi.Server}    server
- * @param  {Object}         options
- * @param  {Function} next
  */
-
 const statusPlugin = {
     name: 'status',
     async register(server) {

--- a/plugins/worker/lib/timeout.js
+++ b/plugins/worker/lib/timeout.js
@@ -7,7 +7,7 @@ const TIMEOUT_CODE = 3;
 const TIMEOUT_BUFFER = 1;
 const DEFAULT_TIMEOUT = 90;
 const hash = `${queuePrefix}timeoutConfigs`;
-const REDIS_LOCK_TTL = 1000; // in ms
+const REDIS_LOCK_TTL = 10000; // in ms
 
 /**
  * Wrapper function to process timeout logic
@@ -96,6 +96,7 @@ async function process(timeoutConfig, buildId, redis, workerId) {
  * @method check
  * @param {Object} redis
  * @param {Object} redlock
+ * @param {String} workerId
  * @return {Promise}
  */
 async function check(redis, redlock, workerId) {
@@ -121,7 +122,7 @@ async function check(redis, redlock, workerId) {
 
                 await lock.unlock();
             } catch (err) {
-                logger.error(`worker[${workerId}] -> Redis locking error ${buildId}`, err.message);
+                logger.error(`worker[${workerId}] -> Redis locking error ${buildId}: ${err.message}`);
             }
         })
     );

--- a/plugins/worker/lib/timeout.js
+++ b/plugins/worker/lib/timeout.js
@@ -6,6 +6,8 @@ const { waitingJobsPrefix, runningJobsPrefix, queuePrefix } = require('../../../
 const TIMEOUT_CODE = 3;
 const TIMEOUT_BUFFER = 1;
 const DEFAULT_TIMEOUT = 90;
+const hash = `${queuePrefix}timeoutConfigs`;
+const REDIS_LOCK_TTL = 1000; // in ms
 
 /**
  * Wrapper function to process timeout logic
@@ -13,9 +15,10 @@ const DEFAULT_TIMEOUT = 90;
  * @param {Object} timeoutConfig
  * @param {String} buildId
  * @param {Object} redis
+ * @param {String} workerId
  * @return {Promise}
  */
-async function process(timeoutConfig, buildId, redis) {
+async function process(timeoutConfig, buildId, redis, workerId) {
     try {
         const { jobId } = timeoutConfig;
         const runningKey = `${runningJobsPrefix}${jobId}`;
@@ -28,7 +31,7 @@ async function process(timeoutConfig, buildId, redis) {
 
         if (!startTime) {
             // there is no startTime set for the build
-            logger.warn(`startTime not set for buildId: ${buildId}`);
+            logger.warn(`worker[${workerId}] -> startTime not set for buildId: ${buildId}`);
 
             return;
         }
@@ -46,7 +49,7 @@ async function process(timeoutConfig, buildId, redis) {
                     buildId
                 });
             } catch (err) {
-                logger.error(`No active step found for ${buildId}`);
+                logger.error(`worker[${workerId}] -> No active step found for ${buildId}`);
             }
 
             if (step) {
@@ -65,7 +68,7 @@ async function process(timeoutConfig, buildId, redis) {
                 statusMessage: 'Build failed due to timeout'
             });
 
-            logger.info(`Build has timed out ${buildId}`);
+            logger.info(`worker[${workerId}] -> Build has timed out ${buildId}`);
 
             await redis.hdel(`${queuePrefix}buildConfigs`, buildId);
 
@@ -77,13 +80,13 @@ async function process(timeoutConfig, buildId, redis) {
             await redis.lrem(waitingKey, 0, buildId);
 
             // remove from timeout configs after build is timed out
-            await redis.hdel(`${queuePrefix}timeoutConfigs`, buildId);
+            await redis.hdel(hash, buildId);
         }
     } catch (err) {
         // delete key from redis in case of error to prevent reprocessing
-        await redis.hdel(`${queuePrefix}timeoutConfigs`, buildId);
+        await redis.hdel(hash, buildId);
 
-        logger.error(`Error occurred while checking timeout for buildId : ${buildId} : ${err}`);
+        logger.error(`worker[${workerId}] -> Error occurred while checking timeout for buildId : ${buildId} : ${err}`);
     }
 }
 
@@ -92,28 +95,58 @@ async function process(timeoutConfig, buildId, redis) {
  * If yes, abort build.
  * @method check
  * @param {Object} redis
+ * @param {Object} redlock
  * @return {Promise}
  */
-async function check(redis) {
-    const keys = await redis.hkeys(`${queuePrefix}timeoutConfigs`);
+async function check(redis, redlock, workerId) {
+    const keys = await redis.hkeys(hash);
 
     if (!keys || keys.length === 0) return;
 
     await Promise.all(
         keys.map(async buildId => {
-            const json = await redis.hget(`${queuePrefix}timeoutConfigs`, buildId);
+            try {
+                const lock = await redlock.lock(buildId, REDIS_LOCK_TTL);
+                const json = await redis.hget(hash, buildId);
 
-            if (!json) return;
-            const timeoutConfig = JSON.parse(json);
+                if (!json) return;
+                const timeoutConfig = JSON.parse(json);
 
-            if (!timeoutConfig) {
-                // this build or pipeline has already been deleted
-                return;
+                if (!timeoutConfig) {
+                    // this build or pipeline has already been deleted
+                    return;
+                }
+
+                await process(timeoutConfig, buildId, redis, workerId);
+
+                await lock.unlock();
+            } catch (err) {
+                logger.error(`worker[${workerId}] -> Redis locking error ${buildId}`, err.message);
             }
-
-            await process(timeoutConfig, buildId, redis);
         })
     );
 }
 
-module.exports.check = check;
+let lastAccessedTime;
+
+/**
+ *
+ * @param {Object} redis
+ * @param {Object} redlock
+ * @param {Number} workerId
+ * @param {Number} pollInterval
+ */
+async function checkWithBackOff(redis, redlock, workerId, pollInterval = 60) {
+    lastAccessedTime = lastAccessedTime || new Date();
+    const diffMs = new Date().getTime() - new Date(lastAccessedTime).getTime();
+    const diffSeconds = Math.round(diffMs / 1000);
+
+    // poll every 60 seconds
+    if (diffSeconds === pollInterval) {
+        logger.info('worker[%s] -> Processing timeout checks', workerId);
+        await check(redis, redlock, workerId);
+        lastAccessedTime = new Date();
+    }
+}
+
+module.exports.checkWithBackOff = checkWithBackOff;

--- a/plugins/worker/worker.js
+++ b/plugins/worker/worker.js
@@ -64,7 +64,7 @@ async function invoke() {
         multiWorker.on('start', workerId => logger.info(`queueWorker->worker[${workerId}] started`));
         multiWorker.on('end', workerId => logger.info(`queueWorker->worker[${workerId}] ended`));
         multiWorker.on('cleaning_worker', (workerId, worker, pid) =>
-            logger.info(`queueWorker->cleaning old worker ${worker} pid ${pid}`)
+            logger.info(`queueWorker->cleaning old worker ${worker}${workerId} pid ${pid}`)
         );
         multiWorker.on('poll', async (workerId, queue) => {
             logger.info(`queueWorker->worker[${workerId}] polling ${queue}`);

--- a/plugins/worker/worker.js
+++ b/plugins/worker/worker.js
@@ -128,7 +128,7 @@ async function invoke() {
             logger.info(`queueWorker->scheduler working timestamp ${timestamp}`)
         );
         scheduler.on('transferred_job', (timestamp, job) =>
-            logger.info(`queueWorker->scheduler enqueuing job timestamp  >>  ${JSON.stringify(job)}`)
+            logger.info(`queueWorker->scheduler enqueuing job timestamp  >> ${timestamp} ${JSON.stringify(job)}`)
         );
 
         multiWorker.start();

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -12,7 +12,8 @@ describe('Register Plugins', () => {
         '../plugins/queue',
         '../plugins/status',
         '../plugins/auth',
-        '../plugins/shutdown'
+        '../plugins/shutdown',
+        '../plugins/logging'
     ];
     const defaultPlugin = ['blipp', 'hapi-auth-jwt2'];
     const pluginLength = resourcePlugins.length + defaultPlugin.length;

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -225,6 +225,31 @@ describe('Helper Test', () => {
         });
     });
 
+    it('Correctly creates build event with reponse code 200', async () => {
+        mockRequestRetry.yieldsAsync(null, { statusCode: 200 });
+        const retryFn = sinon.stub();
+
+        try {
+            await helper.createBuildEvent('foo.bar', 'fake', { buildId: 1, eventId: 321, jobId: 123 }, retryFn);
+        } catch (err) {
+            assert.isNull(err);
+        }
+
+        assert.calledWith(mockRequestRetry, {
+            json: true,
+            method: 'POST',
+            uri: 'foo.bar/v4/events',
+            headers: {
+                Authorization: 'Bearer fake',
+                'Content-Type': 'application/json'
+            },
+            body: { buildId: 1, eventId: 321, jobId: 123 },
+            maxAttempts: 3,
+            retryDelay: 5000,
+            retryStrategy: retryFn
+        });
+    });
+
     it('Gets the pipeline admin correctly', async () => {
         mockRequestRetry.yieldsAsync(null, {
             statusCode: 200,

--- a/test/plugins/worker/lib/timeout.test.js
+++ b/test/plugins/worker/lib/timeout.test.js
@@ -18,6 +18,8 @@ describe('Timeout test', () => {
     let mockRedisConfig;
     let helperMock;
     let timeout;
+    let mockRedlock;
+    let mockLockObj;
 
     before(() => {
         mockery.enable({
@@ -35,6 +37,14 @@ describe('Timeout test', () => {
             del: sinon.stub().resolves(),
             lrem: sinon.stub().resolves(),
             hkeys: sinon.stub().resolves()
+        };
+
+        mockRedlock = {
+            lock: sinon.stub().resolves()
+        };
+
+        mockLockObj = {
+            unlock: sinon.stub().resolves()
         };
 
         mockRedisConfig = {
@@ -72,6 +82,8 @@ describe('Timeout test', () => {
             waitingKey = `${waitingJobsPrefix}2`;
 
             mockRedis.hkeys.withArgs(`${queuePrefix}timeoutConfigs`).resolves(['222', '333', '444']);
+            mockRedlock.lock.withArgs('333', 1000).resolves(mockLockObj);
+            mockRedlock.lock.withArgs('222', 1000).resolves(mockLockObj);
         });
 
         it('Updates build status to FAILURE if time difference is greater than timeout', async () => {
@@ -101,7 +113,7 @@ describe('Timeout test', () => {
 
             mockRedis.hget.withArgs(`${queuePrefix}timeoutConfigs`, buildId).resolves(JSON.stringify(timeoutConfig));
 
-            await timeout.check(mockRedis);
+            await timeout.checkWithBackOff(mockRedis, mockRedlock, 1, 0);
 
             assert.calledWith(helperMock.updateBuildStatus, {
                 redisInstance: mockRedis,
@@ -144,7 +156,7 @@ describe('Timeout test', () => {
 
             mockRedis.hget.withArgs(`${queuePrefix}timeoutConfigs`, buildId).resolves(JSON.stringify(timeoutConfig));
 
-            await timeout.check(mockRedis);
+            await timeout.checkWithBackOff(mockRedis, mockRedlock, 1, 0);
 
             assert.calledWith(helperMock.updateStepStop, {
                 redisInstance: mockRedis,
@@ -168,7 +180,7 @@ describe('Timeout test', () => {
 
             mockRedis.hget.withArgs(`${queuePrefix}timeoutConfigs`, buildId).resolves(JSON.stringify(timeoutConfig));
 
-            await timeout.check(mockRedis);
+            await timeout.checkWithBackOff(mockRedis, mockRedlock, 1, 0);
 
             assert.notCalled(helperMock.getCurrentStep);
             assert.notCalled(helperMock.updateStepStop);
@@ -194,7 +206,7 @@ describe('Timeout test', () => {
 
             mockRedis.hget.withArgs(`${queuePrefix}timeoutConfigs`, buildId).resolves(JSON.stringify(timeoutConfig));
 
-            await timeout.check(mockRedis);
+            await timeout.checkWithBackOff(mockRedis, mockRedlock, 1, 0);
 
             assert.calledWith(helperMock.updateBuildStatus, {
                 redisInstance: mockRedis,
@@ -220,7 +232,7 @@ describe('Timeout test', () => {
 
             mockRedis.hget.withArgs(`${queuePrefix}timeoutConfigs`, buildId).resolves(JSON.stringify(timeoutConfig));
 
-            await timeout.check(mockRedis);
+            await timeout.checkWithBackOff(mockRedis, mockRedlock, 1, 0);
 
             assert.notCalled(helperMock.getCurrentStep);
             assert.notCalled(helperMock.updateStepStop);
@@ -245,7 +257,7 @@ describe('Timeout test', () => {
             mockRedis.hget.withArgs(`${queuePrefix}timeoutConfigs`, buildId).resolves(JSON.stringify(timeoutConfig));
             helperMock.getCurrentStep.resolves(null);
 
-            await timeout.check(mockRedis);
+            await timeout.checkWithBackOff(mockRedis, mockRedlock, 1, 0);
 
             assert.notCalled(helperMock.updateStepStop);
             assert.calledWith(helperMock.updateBuildStatus, {
@@ -261,6 +273,25 @@ describe('Timeout test', () => {
             assert.calledWith(mockRedis.del, deleteKey);
             assert.calledWith(mockRedis.lrem, waitingKey, 0, buildId);
             assert.calledWith(mockRedis.hdel, `${queuePrefix}timeoutConfigs`, buildId);
+        });
+
+        it('Skip execution if polling interval is not reached', async () => {
+            const buildId = '222';
+            const timeoutConfig = {
+                jobId: 2,
+                timeout: 50
+            };
+
+            mockRedis.hget.withArgs(`${queuePrefix}timeoutConfigs`, buildId).resolves(JSON.stringify(timeoutConfig));
+
+            await timeout.checkWithBackOff(mockRedis, mockRedlock, 1, 5);
+
+            assert.notCalled(helperMock.getCurrentStep);
+            assert.notCalled(helperMock.updateStepStop);
+            assert.notCalled(helperMock.updateBuildStatus);
+            assert.notCalled(mockRedis.expire);
+            assert.notCalled(mockRedis.del);
+            assert.notCalled(mockRedis.lrem);
         });
     });
 });

--- a/test/plugins/worker/worker.test.js
+++ b/test/plugins/worker/worker.test.js
@@ -309,7 +309,7 @@ describe('Schedule test', () => {
             testScheduler.emit('transferred_job', timestamp, job);
             assert.calledWith(
                 winstonMock.info,
-                `queueWorker->scheduler enqueuing job timestamp  >>  ${JSON.stringify(job)}`
+                `queueWorker->scheduler enqueuing job timestamp  >> ${timestamp} ${JSON.stringify(job)}`
             );
         });
     });

--- a/test/plugins/worker/worker.test.js
+++ b/test/plugins/worker/worker.test.js
@@ -195,7 +195,7 @@ describe('Schedule test', () => {
             assert.calledWith(winstonMock.info, `queueWorker->worker[${workerId}] ended`);
 
             testWorker.emit('cleaning_worker', workerId, worker, pid);
-            assert.calledWith(winstonMock.info, `queueWorker->cleaning old worker ${worker} pid ${pid}`);
+            assert.calledWith(winstonMock.info, `queueWorker->cleaning old worker ${worker}${workerId} pid ${pid}`);
 
             testWorker.emit('poll', workerId, queue);
             assert.calledWith(winstonMock.info, `queueWorker->worker[${workerId}] polling ${queue}`);

--- a/test/plugins/worker/worker.test.js
+++ b/test/plugins/worker/worker.test.js
@@ -55,6 +55,8 @@ describe('Schedule test', () => {
     let configMock;
     let timeoutMock;
     let clock;
+    let mockRedlockObj;
+    let mockRedlock;
 
     before(() => {
         mockery.enable({
@@ -91,7 +93,7 @@ describe('Schedule test', () => {
             updateBuildStatus: sinon.stub()
         };
         timeoutMock = {
-            check: sinon.stub()
+            checkWithBackOff: sinon.stub()
         };
         processExitMock = sinon.stub();
         process.exit = processExitMock;
@@ -110,6 +112,10 @@ describe('Schedule test', () => {
         mockRedisObj = {
             hget: sinon.stub().resolves('{"apiUri": "foo.bar", "token": "fake"}')
         };
+        mockRedlockObj = {
+            lock: sinon.stub().resolves()
+        };
+        mockRedlock = sinon.stub().returns(mockRedlockObj);
         mockRedis = sinon.stub().returns(mockRedisObj);
         configMock = {
             get: sinon.stub()
@@ -119,6 +125,7 @@ describe('Schedule test', () => {
         mockery.registerMock('request', requestMock);
         mockery.registerMock('../../config/redis', redisConfigMock);
         mockery.registerMock('ioredis', mockRedis);
+        mockery.registerMock('redlock', mockRedlock);
         mockery.registerMock('../helper', helperMock);
         mockery.registerMock('./lib/timeout', timeoutMock);
         mockery.registerMock('config', configMock);
@@ -192,7 +199,7 @@ describe('Schedule test', () => {
 
             testWorker.emit('poll', workerId, queue);
             assert.calledWith(winstonMock.info, `queueWorker->worker[${workerId}] polling ${queue}`);
-            assert.calledWith(timeoutMock.check);
+            assert.calledWith(timeoutMock.checkWithBackOff, mockRedisObj, mockRedlockObj, workerId);
 
             testWorker.emit('job', workerId, queue, job);
             assert.calledWith(


### PR DESCRIPTION
## Context

When multiple node-resque workers start polling it results in unnecessary chatty calls to Redis every 5 seconds which is not optimized. With no lock checks this results the same buildId be processed several times based on the no of active workers. Also multiple polling by workers every  5seconds is not very desirable for timeout use case.

## Objective

This PR fixes the above issues:
 1. Adds a lock of 1sec on the key buildId in redis and unlocks it after processing. At the same instant if any other worker tries to acquire lock it fails and goes to the next item
 2. Since we cannot modify the node-resque polling time, it adds a backoff strategy to the polling by workers and reduces polling interval  to every 60 seconds.

## References

https://github.com/mike-marcacci/node-redlock/blob/master/README.md#usage-promise-style

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
