### PR TITLE
feat(2087): Cache Clear feature implementation

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -33,6 +33,7 @@ module.exports = class ExecutorQueue {
         this.tokenGen = null;
         this.userTokenGen = null;
         this.timeoutQueue = `${this.prefix}timeoutConfigs`;
+        this.cacheQueue = `${this.prefix}cache`;
 
         const redisConnection = { ...config.redisConnection, pkg: 'ioredis' };
 

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -11,7 +11,7 @@ const AuthJWT = require('hapi-auth-jwt2');
  */
 async function registerResourcePlugins(server, config) {
     try {
-        const plugins = ['worker', 'queue', 'status', 'auth', 'shutdown', 'logging'];
+        const plugins = ['auth', 'worker', 'queue', 'status', 'shutdown', 'logging'];
 
         return plugins.map(pluginName =>
             server.register({

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -44,8 +44,6 @@ const authPlugin = {
         });
         server.auth.strategy('default', 'custom');
 
-        server.auth.default('default');
-
         /**
          * Generates a profile for storage in cookie and jwt
          * @method generateProfile

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -44,6 +44,8 @@ const authPlugin = {
         });
         server.auth.strategy('default', 'custom');
 
+        server.auth.default('default');
+
         /**
          * Generates a profile for storage in cookie and jwt
          * @method generateProfile

--- a/plugins/queue/delete.js
+++ b/plugins/queue/delete.js
@@ -10,6 +10,10 @@ module.exports = () => ({
         description: 'Deletes a message to the queue',
         notes: 'Should delete a message from the queue',
         tags: ['api', 'queue'],
+        auth: {
+            strategies: ['token'],
+            scope: ['sdapi']
+        },
         handler: async (request, h) => {
             try {
                 const executor = request.server.app.executorQueue;

--- a/plugins/queue/put.js
+++ b/plugins/queue/put.js
@@ -10,8 +10,14 @@ module.exports = () => ({
         description: 'Puts a message to the queue',
         notes: 'Should add a message to the queue',
         tags: ['api', 'queue'],
+        auth: {
+            strategies: ['token'],
+            scope: ['sdapi']
+        },
         handler: async (request, h) => {
             try {
+                console.log(request.server.app);
+
                 const executor = request.server.app.executorQueue;
 
                 const { type } = request.query;

--- a/plugins/queue/put.js
+++ b/plugins/queue/put.js
@@ -16,8 +16,6 @@ module.exports = () => ({
         },
         handler: async (request, h) => {
             try {
-                console.log(request.server.app);
-
                 const executor = request.server.app.executorQueue;
 
                 const { type } = request.query;

--- a/plugins/queue/put.js
+++ b/plugins/queue/put.js
@@ -26,6 +26,9 @@ module.exports = () => ({
                     case 'timer':
                         await scheduler.startTimer(executor, request.payload);
                         break;
+                    case 'cache':
+                        await scheduler.clearCache(executor, request.payload);
+                        break;
                     default:
                         await scheduler.start(executor, request.payload);
                         break;

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -616,6 +616,31 @@ async function cleanUp(executor) {
     }
 }
 
+/**
+ * Pushes a message to cache queue to clear it
+ * @async  clearCache
+ * @param {Object} executor
+ * @param {Object} config
+ */
+async function clearCache(executor, config) {
+    try {
+        await executor.connect();
+
+        return await executor.queueBreaker.runCommand('enqueue', executor.cacheQueue, 'clear', [
+            {
+                resource: 'caches',
+                action: 'delete',
+                prefix: executor.prefix,
+                ...config
+            }
+        ]);
+    } catch (err) {
+        logger.error(`Error occurred while saving to cache queue ${err}`);
+
+        throw err;
+    }
+}
+
 module.exports = {
     init,
     start,
@@ -626,5 +651,6 @@ module.exports = {
     stopFrozen,
     startTimer,
     stopTimer,
-    cleanUp
+    cleanUp,
+    clearCache
 };

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -248,8 +248,8 @@ async function start(executor, config) {
         jobArchived,
         blockedBy,
         freezeWindows,
-        token,
-        apiUri
+        apiUri,
+        pipeline
     } = config;
     const forceStart = /\[(force start)\]/.test(causeMessage);
 
@@ -281,6 +281,16 @@ async function start(executor, config) {
         });
     }
 
+    const tokenConfig = {
+        username: buildId,
+        buildId,
+        jobId,
+        eventId: build && build.eventId,
+        pipelineId: pipeline && pipeline.id,
+        scmContext: pipeline && pipeline.scmContext
+    };
+    const buildToken = executor.tokenGen(Object.assign(tokenConfig, { scope: ['build'] }));
+
     // Check freeze window
     if (currentTime.getTime() > origTime.getTime() && !forceStart) {
         const payload = {
@@ -296,7 +306,7 @@ async function start(executor, config) {
             .updateBuild(
                 {
                     buildId,
-                    token,
+                    token: buildToken,
                     apiUri,
                     payload
                 },
@@ -330,6 +340,8 @@ async function start(executor, config) {
             ]
         );
     } else {
+        const token = executor.tokenGen(Object.assign(tokenConfig, { scope: ['temporal'] }));
+
         // set the start time in the queue
         Object.assign(config, { token });
         // Store the config in redis
@@ -347,7 +359,7 @@ async function start(executor, config) {
             await helper.updateBuild(
                 {
                     buildId,
-                    token,
+                    token: buildToken,
                     apiUri,
                     payload: { stats: build.stats }
                 },

--- a/plugins/worker/create.js
+++ b/plugins/worker/create.js
@@ -10,6 +10,10 @@ module.exports = () => ({
         description: 'Start worker to read and process messages from the queue',
         notes: 'Should start worker to process messages from the queue',
         tags: ['api', 'queue'],
+        auth: {
+            strategies: ['token'],
+            scope: ['sdapi']
+        },
         handler: async (request, h) => {
             try {
                 const result = await worker.invoke(request);

--- a/plugins/worker/lib/CacheFilter.js
+++ b/plugins/worker/lib/CacheFilter.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const NodeResque = require('node-resque');
+
+class CacheFilter extends NodeResque.Plugin {
+    /**
+     * Construct a new Filter plugin
+     * @method constructor
+     */
+    constructor(worker, func, queue, job, args, options) {
+        super(worker, func, queue, job, args, options);
+
+        this.name = 'CacheFilter';
+    }
+
+    /**
+     * Checks if the job belongs to this worker
+     * @method beforePerform
+     * @return {Promise}
+     */
+    async beforePerform() {
+        const { id, resource } = this.args[0];
+
+        if (!id || resource !== 'caches') {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+exports.CacheFilter = CacheFilter;

--- a/plugins/worker/lib/CacheFilter.js
+++ b/plugins/worker/lib/CacheFilter.js
@@ -14,7 +14,7 @@ class CacheFilter extends NodeResque.Plugin {
     }
 
     /**
-     * Checks if the job belongs to this worker
+     * Checks if the job is a cache invalidation job
      * @method beforePerform
      * @return {Promise}
      */

--- a/plugins/worker/lib/timeout.js
+++ b/plugins/worker/lib/timeout.js
@@ -149,8 +149,8 @@ async function checkWithBackOff(redis, redlock, workerId, pollInterval = 60) {
     // poll every 60 seconds
     if (diffSeconds >= pollInterval) {
         logger.info('worker[%s] -> Processing timeout checks', workerId);
-        await check(redis, redlock, workerId);
         workerAccessMap[workerId] = new Date();
+        await check(redis, redlock, workerId);
     }
 }
 

--- a/plugins/worker/worker.js
+++ b/plugins/worker/worker.js
@@ -42,7 +42,7 @@ async function shutDownAll(worker, scheduler) {
 const multiWorker = new NodeResque.MultiWorker(
     {
         connection: connectionDetails,
-        queues: [`${queuePrefix}builds`],
+        queues: [`${queuePrefix}builds`, `${queuePrefix}cache`],
         minTaskProcessors: workerConfig.minTaskProcessors,
         maxTaskProcessors: workerConfig.maxTaskProcessors,
         checkTimeout: workerConfig.checkTimeout,

--- a/test/data/fullConfig.json
+++ b/test/data/fullConfig.json
@@ -10,6 +10,21 @@
   "container": "node:4",
   "apiUri": "http://api.com",
   "token": "asdf",
-  "blockedBy": [777, 888],
-  "freezeWindows": ["* * ? * 1", "0-59 0-23 * 1 ?"]
+  "blockedBy": [
+    777,
+    888
+  ],
+  "freezeWindows": [
+    "* * ? * 1",
+    "0-59 0-23 * 1 ?"
+  ],
+  "pipeline": {
+    "id": 123,
+    "scmUri": "github.com:12345:branchName",
+    "scmContext": "github:github.com",
+    "createTime": "2038-01-19T03:14:08.131Z",
+    "admins": {
+      "stjohn": true
+    }
+  }
 }

--- a/test/lib/queue.test.js
+++ b/test/lib/queue.test.js
@@ -99,6 +99,7 @@ describe('queue test', () => {
             assert.strictEqual(executor.buildQueue, 'beta_builds');
             assert.strictEqual(executor.buildConfigTable, 'beta_buildConfigs');
             assert.strictEqual(executor.timeoutQueue, 'beta_timeoutConfigs');
+            assert.strictEqual(executor.cacheQueue, 'beta_cache');
         });
 
         it('throws when not given a redis connection', () => {

--- a/test/plugins/queue/index.test.js
+++ b/test/plugins/queue/index.test.js
@@ -12,6 +12,13 @@ describe('queue plugin test', () => {
     let plugin;
     let server;
     let schedulerMock;
+    let authMock;
+    let generateTokenMock;
+    let generateProfileMock;
+    let options;
+    const jwtPrivateKey = 'test key';
+    const jwtPublicKey = 'test public key';
+    const jwtSDApiPublicKey = 'test api pubclic key';
 
     before(() => {
         mockery.enable({
@@ -22,20 +29,67 @@ describe('queue plugin test', () => {
 
     beforeEach(async () => {
         schedulerMock = {
-            init: sinon.stub().resolves()
+            start: sinon.stub().resolves(),
+            startTimer: sinon.stub().resolves(),
+            startFrozen: sinon.stub().resolves(),
+            startPeriodic: sinon.stub().resolves(),
+            stop: sinon.stub().resolves(),
+            stopTimer: sinon.stub().resolves(),
+            stopFrozen: sinon.stub().resolves(),
+            stopPeriodic: sinon.stub().resolves(),
+            clearCache: sinon.stub().resolves()
         };
 
-        mockery.registerMock('./schdeuler', schedulerMock);
+        mockery.registerMock('./scheduler', schedulerMock);
+
+        generateProfileMock = sinon.stub();
+        generateTokenMock = sinon.stub();
 
         /* eslint-disable global-require */
-        plugin = require('../../../plugins/queue');
+        plugin = require('../../../plugins/queue/index.js');
         /* eslint-enable global-require */
         server = new hapi.Server({
             port: 1234
         });
+        server.auth.scheme('custom', () => ({
+            authenticate: (_, h) => {
+                return h.authenticated({
+                    credentials: {
+                        scope: ['sdapi']
+                    }
+                });
+            }
+        }));
+        server.auth.strategy('token', 'custom');
+
+        authMock = {
+            name: 'auth',
+            async register(s) {
+                s.expose('generateToken', generateTokenMock);
+                s.expose('generateProfile', generateProfileMock);
+            }
+        };
+
+        server.register({
+            plugin: authMock,
+            options: {
+                jwtPrivateKey,
+                jwtPublicKey,
+                jwtSDApiPublicKey
+            },
+            routes: {
+                prefix: '/v1'
+            }
+        });
 
         await server.register({
-            plugin
+            plugin,
+            options: {
+                name: 'queue'
+            },
+            routes: {
+                prefix: '/v1'
+            }
         });
     });
 
@@ -52,6 +106,135 @@ describe('queue plugin test', () => {
     describe('constructor', () => {
         it('registers the queue plugin', () => {
             assert.isOk(server.registrations.queue);
+        });
+    });
+
+    describe('DELETE /queue/message', () => {
+        beforeEach(() => {
+            options = {
+                method: 'DELETE',
+                payload: {},
+                url: '/v1/queue/message',
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['sdapi']
+                    }
+                }
+            };
+        });
+
+        it('returns 200 when deleting message from queue', async () => {
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+        });
+
+        it('returns 500 when build update returns an error', async () => {
+            schedulerMock.stop.rejects('some error');
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 500);
+        });
+
+        it('returns 403 Insufficient scope when scope is not sdapi', async () => {
+            options.auth = {
+                strategy: 'token',
+                credentials: {
+                    scope: ['user']
+                }
+            };
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 403);
+        });
+
+        it('returns 200 when deleting message from queue', async () => {
+            options.url = '/v1/queue/message?type=periodic';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.stopPeriodic);
+        });
+
+        it('returns 200 when deleting message from queue', async () => {
+            options.url = '/v1/queue/message?type=timer';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.stopTimer);
+        });
+    });
+
+    describe('POST /queue/message', () => {
+        beforeEach(() => {
+            options = {
+                method: 'POST',
+                payload: {},
+                url: '/v1/queue/message',
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['sdapi']
+                    }
+                }
+            };
+        });
+
+        it('returns 200 when pushing message to queue', async () => {
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+        });
+
+        it('returns 500 when build update returns an error', async () => {
+            schedulerMock.start.rejects('some error');
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 500);
+        });
+
+        it('returns 403 Insufficient scope when scope is not sdapi', async () => {
+            options.auth = {
+                strategy: 'token',
+                credentials: {
+                    scope: ['user']
+                }
+            };
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 403);
+        });
+
+        it('returns 200 when deleting message from queue', async () => {
+            options.url = '/v1/queue/message?type=periodic';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.startPeriodic);
+        });
+
+        it('returns 200 when deleting message from queue', async () => {
+            options.url = '/v1/queue/message?type=cache';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.clearCache);
+        });
+
+        it('returns 200 when deleting message from queue', async () => {
+            options.url = '/v1/queue/message?type=timer';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.startTimer);
         });
     });
 });

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -112,6 +112,7 @@ describe('scheduler test', () => {
             updateBuild: sinon.stub().resolves()
         };
         buildMock = {
+            eventId: 4566,
             update: sinon.stub().resolves({
                 id: buildId
             })
@@ -341,6 +342,9 @@ describe('scheduler test', () => {
     });
 
     describe('start', () => {
+        beforeEach(() => {
+            executor.tokenGen.returns('buildToken');
+        });
         it("rejects if it can't establish a connection", () => {
             queueMock.connect.rejects(new Error("couldn't connect"));
 
@@ -369,11 +373,12 @@ describe('scheduler test', () => {
                 assert.calledTwice(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId, JSON.stringify(testConfig));
                 assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledTwice(executor.tokenGen);
                 assert.calledWith(
                     helperMock.updateBuild,
                     {
                         buildId,
-                        token: 'asdf',
+                        token: 'buildToken',
                         apiUri: 'http://api.com',
                         payload: { stats: buildMock.stats }
                     },
@@ -400,11 +405,12 @@ describe('scheduler test', () => {
                 assert.calledTwice(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId, JSON.stringify(testConfig));
                 assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledTwice(executor.tokenGen);
                 assert.calledWith(
                     helperMock.updateBuild,
                     {
                         buildId,
-                        token: 'asdf',
+                        token: 'buildToken',
                         apiUri: 'http://api.com',
                         payload: { stats: buildMock.stats }
                     },
@@ -484,9 +490,11 @@ describe('scheduler test', () => {
 
             sandbox.useFakeTimers(dateNow.getTime());
 
+            executor.tokenGen.returns('buildToken');
+
             const options = {
                 buildId: testConfig.buildId,
-                token: 'asdf',
+                token: 'buildToken',
                 apiUri: 'http://api.com',
                 payload: {
                     status: 'FROZEN',
@@ -508,6 +516,7 @@ describe('scheduler test', () => {
                     }
                 ]);
                 assert.calledWith(helperMock.updateBuild, options, executor.requestRetryStrategy);
+                assert.calledOnce(executor.tokenGen);
                 sandbox.restore();
             });
         });

--- a/test/plugins/queue/stats.test.js
+++ b/test/plugins/queue/stats.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const chai = require('chai');
+const { assert } = chai;
+const hapi = require('@hapi/hapi');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('queue plugin test', () => {
+    let plugin;
+    let server;
+    let authMock;
+    let generateTokenMock;
+    let generateProfileMock;
+    let options;
+    const jwtPrivateKey = 'test key';
+    const jwtPublicKey = 'test public key';
+    const jwtSDApiPublicKey = 'test api pubclic key';
+
+    beforeEach(async () => {
+        generateProfileMock = sinon.stub();
+        generateTokenMock = sinon.stub();
+
+        /* eslint-disable global-require */
+        plugin = require('../../../plugins/queue/index.js');
+        /* eslint-enable global-require */
+        server = new hapi.Server({
+            port: 1234
+        });
+        server.auth.scheme('custom', () => ({
+            authenticate: (_, h) => {
+                return h.authenticated();
+            }
+        }));
+        server.auth.strategy('token', 'custom');
+
+        authMock = {
+            name: 'auth',
+            async register(s) {
+                s.expose('generateToken', generateTokenMock);
+                s.expose('generateProfile', generateProfileMock);
+            }
+        };
+
+        server.register({
+            plugin: authMock,
+            options: {
+                jwtPrivateKey,
+                jwtPublicKey,
+                jwtSDApiPublicKey
+            },
+            routes: {
+                prefix: '/v1'
+            }
+        });
+
+        await server.register({
+            plugin,
+            options: {
+                name: 'queue'
+            },
+            routes: {
+                prefix: '/v1'
+            }
+        });
+        server.app = {
+            executorQueue: {
+                stats: sinon.stub().returns()
+            }
+        };
+    });
+
+    after(() => {
+        server = null;
+    });
+
+    describe('constructor', () => {
+        it('registers the queue plugin', () => {
+            assert.isOk(server.registrations.queue);
+        });
+    });
+
+    describe('GET /queue/stats', () => {
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: '/v1/queue/stats'
+            };
+        });
+
+        it('returns 200 when fetching stats', async () => {
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+        });
+
+        it('Does not return 403 when scope is different', async () => {
+            options = {
+                method: 'GET',
+                url: '/v1/queue/stats',
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['somescope']
+                    }
+                }
+            };
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+        });
+    });
+});

--- a/test/plugins/worker/lib/cacheFilter.test.js
+++ b/test/plugins/worker/lib/cacheFilter.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const { assert } = require('chai');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('CacheFilter Plugin Test', () => {
+    const mockJob = {};
+    const mockFunc = () => {};
+    const mockQueue = 'queuename';
+    let mockWorker;
+    let mockArgs;
+    let mockRedis;
+    let CacheFilter;
+    let filter;
+    let buildConfig;
+    let mockRabbitmqConfigObj;
+    let mockRabbitmqConfig;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        mockArgs = [
+            {
+                id: 123,
+                resource: 'caches',
+                scope: 'pipelines',
+                action: 'delete',
+                prefix: '',
+                buildClusters: ['sd1', 'sd2']
+            }
+        ];
+
+        buildConfig = {
+            buildClusterName: 'sd1'
+        };
+
+        mockRedis = {
+            hget: sinon.stub().resolves(JSON.stringify(buildConfig))
+        };
+
+        mockWorker = {
+            queueObject: {
+                connection: {
+                    redis: mockRedis
+                },
+                enqueueIn: sinon.stub().resolves()
+            }
+        };
+
+        mockRabbitmqConfigObj = {
+            schedulerMode: false,
+            amqpURI: 'amqp://localhost:5672',
+            exchange: 'build'
+        };
+
+        mockRabbitmqConfig = {
+            getConfig: sinon.stub().returns(mockRabbitmqConfigObj)
+        };
+
+        mockery.registerMock('../../../config/rabbitmq', mockRabbitmqConfig);
+        mockery.registerMock('ioredis', mockRedis);
+
+        // eslint-disable-next-line global-require
+        CacheFilter = require('../../../../plugins/worker/lib/CacheFilter.js').CacheFilter;
+
+        filter = new CacheFilter(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {});
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('Filter', () => {
+        it('constructor', async () => {
+            assert.equal(filter.name, 'CacheFilter');
+        });
+
+        describe('beforePerform', () => {
+            it('proceeds if config has resource as caches', async () => {
+                const proceed = await filter.beforePerform();
+
+                assert.isTrue(proceed);
+            });
+
+            it("doesn't proceed if build has no id or resource", async () => {
+                mockArgs = [
+                    {
+                        id: 123,
+                        resource: null,
+                        scope: 'pipelines',
+                        action: 'delete',
+                        prefix: ''
+                    }
+                ];
+                filter = new CacheFilter(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {});
+
+                const proceed = await filter.beforePerform();
+
+                assert.isFalse(proceed);
+            });
+        });
+    });
+});

--- a/test/plugins/worker/worker.test.js
+++ b/test/plugins/worker/worker.test.js
@@ -20,6 +20,7 @@ describe('Schedule test', () => {
     const job = { args: [{ buildId: 1 }] };
     const queue = 'testbuilds';
     const workerConfig = {
+        queues: ['mockQueuePrefix_builds', 'mockQueuePrefix_cache'],
         minTaskProcessors: 123,
         maxTaskProcessors: 234,
         checkTimeout: 345,
@@ -67,7 +68,8 @@ describe('Schedule test', () => {
 
     beforeEach(() => {
         mockJobs = {
-            start: sinon.stub()
+            start: sinon.stub(),
+            clear: sinon.stub()
         };
         MultiWorker = sinon.stub();
         MultiWorker.prototype.start = () => {};
@@ -207,6 +209,14 @@ describe('Schedule test', () => {
                 `queueWorker->worker[${workerId}] working job ${queue} ${JSON.stringify(job)}`
             );
 
+            const cacheJob = { id: 123, resource: 'caches' };
+
+            testWorker.emit('job', workerId, 'cache', cacheJob);
+            assert.calledWith(
+                winstonMock.info,
+                `queueWorker->worker[${workerId}] working job cache ${JSON.stringify(cacheJob)}`
+            );
+
             testWorker.emit('reEnqueue', workerId, queue, job, plugin);
             assert.calledWith(
                 winstonMock.info,
@@ -327,7 +337,8 @@ describe('Schedule test', () => {
                 MultiWorker,
                 sinon.match(workerConfig),
                 sinon.match({
-                    start: mockJobs.start
+                    start: mockJobs.start,
+                    clear: mockJobs.clear
                 })
             );
         });


### PR DESCRIPTION
## Context
Cache cleanup buttons in Pipeline settings page, does not clear the cache when using disk cache.

## Objective
This PR implements a cache clear mechanism for disk based strategy by sending a message to the rabbitmq consumer

## References
https://github.com/screwdriver-cd/screwdriver/issues/2087

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
