### PR TITLE
fix: Increase jwt temporal token expiry to 12hrs

### DIFF
--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -12,6 +12,7 @@ const DEFAULT_BUILD_TIMEOUT = 90;
 const RETRY_LIMIT = 3;
 const RETRY_DELAY = 5;
 const EXPIRE_TIME = 1800; // 30 mins
+const TEMPORAL_TOKEN_TIMEOUT = 12 * 60; // 12 hours in minutes
 
 /**
  * Posts a new build event to the API
@@ -364,7 +365,7 @@ async function start(executor, config) {
             throw value.error;
         }
 
-        const token = executor.tokenGen(Object.assign(tokenConfig, { scope: ['temporal'] }));
+        const token = executor.tokenGen(Object.assign(tokenConfig, { scope: ['temporal'] }), TEMPORAL_TOKEN_TIMEOUT);
 
         // set the start time in the queue
         Object.assign(config, { token });

--- a/plugins/worker/lib/jobs.js
+++ b/plugins/worker/lib/jobs.js
@@ -105,7 +105,7 @@ function pushToRabbitMq(message, queue, messageId) {
             return channelWrapper.close();
         })
         .catch(err => {
-            logger.error('publishing failed to rabbitmq:', err.message);
+            logger.error('publishing failed to rabbitmq: %s', err.message);
             channelWrapper.close();
 
             throw err;

--- a/plugins/worker/worker.js
+++ b/plugins/worker/worker.js
@@ -67,8 +67,10 @@ async function invoke() {
             logger.info(`queueWorker->cleaning old worker ${worker}${workerId} pid ${pid}`)
         );
         multiWorker.on('poll', async (workerId, queue) => {
-            logger.info(`queueWorker->worker[${workerId}] polling ${queue}`);
-            await timeout.checkWithBackOff(redis, redlock, workerId);
+            if (queue === 'builds') {
+                logger.info(`queueWorker->worker[${workerId}] polling ${queue}`);
+                await timeout.checkWithBackOff(redis, redlock, workerId);
+            }
         });
         multiWorker.on('job', (workerId, queue, job) =>
             logger.info(`queueWorker->worker[${workerId}] working job ${queue} ${JSON.stringify(job)}`)

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -24,6 +24,7 @@ const partialTestConfigToString = Object.assign({}, partialTestConfig, {
 const testAdmin = {
     username: 'admin'
 };
+const TEMPORAL_TOKEN_TIMEOUT = 12 * 60; // 12 hours in minutes
 
 sinon.assert.expose(chai.assert, { prefix: '' });
 
@@ -446,6 +447,34 @@ describe('scheduler test', () => {
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId, JSON.stringify(testConfig));
                 assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
                 assert.calledTwice(executor.tokenGen);
+                assert.calledWith(executor.tokenGen, {
+                    buildId: testConfig.buildId,
+                    configPipelineId: testConfig.pipeline.configPipelineId,
+                    eventId: buildMock.eventId,
+                    isPR: testConfig.isPR,
+                    jobId: testConfig.jobId,
+                    pipelineId: testConfig.pipeline.id,
+                    prParentJobId: testConfig.prParentJobId,
+                    scmContext: testConfig.pipeline.scmContext,
+                    scope: ['build'],
+                    username: testConfig.buildId
+                });
+                assert.calledWith(
+                    executor.tokenGen,
+                    {
+                        buildId: testConfig.buildId,
+                        configPipelineId: testConfig.pipeline.configPipelineId,
+                        eventId: buildMock.eventId,
+                        isPR: testConfig.isPR,
+                        jobId: testConfig.jobId,
+                        pipelineId: testConfig.pipeline.id,
+                        prParentJobId: testConfig.prParentJobId,
+                        scmContext: testConfig.pipeline.scmContext,
+                        scope: ['temporal'],
+                        username: testConfig.buildId
+                    },
+                    TEMPORAL_TOKEN_TIMEOUT
+                );
                 assert.calledWith(
                     helperMock.updateBuild,
                     {

--- a/test/plugins/worker/worker.test.js
+++ b/test/plugins/worker/worker.test.js
@@ -200,7 +200,10 @@ describe('Schedule test', () => {
             assert.calledWith(winstonMock.info, `queueWorker->cleaning old worker ${worker}${workerId} pid ${pid}`);
 
             testWorker.emit('poll', workerId, queue);
-            assert.calledWith(winstonMock.info, `queueWorker->worker[${workerId}] polling ${queue}`);
+            assert.notCalled(timeoutMock.checkWithBackOff);
+
+            testWorker.emit('poll', workerId, 'builds');
+            assert.calledWith(winstonMock.info, `queueWorker->worker[${workerId}] polling builds`);
             assert.calledWith(timeoutMock.checkWithBackOff, mockRedisObj, mockRedlockObj, workerId);
 
             testWorker.emit('job', workerId, queue, job);


### PR DESCRIPTION
## Context

JWT token generation had a default expiry time of 1 hr, many builds may run for several hours being blocked so we need to increase the expiry

## Objective

This PR increases the temporal token expiry to 12hrs

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
