### PR TITLE
fix: use runtimeClass without buildcluster-queue-worker

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -24,6 +24,8 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: K8S_HOST
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
+            privileged: K8S_SECURITYCONTEXT_PRIVILEGED
             # The jwt token used for authenticating kubernetes requests
             token: K8S_TOKEN
             jobsNamespace: K8S_JOBS_NAMESPACE
@@ -70,6 +72,8 @@ executor:
             annotations:
               __name: K8S_ANNOTATIONS
               __format: json
+            # support for kata-containers-as-a-runtimeclass
+            runtimeClass: K8S_RUNTIME_CLASS
         # Launcher image to use
         launchImage: LAUNCH_IMAGE
         # Launcher container tag to use
@@ -91,6 +95,8 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: K8S_HOST
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
+            privileged: K8S_SECURITYCONTEXT_PRIVILEGED
             # The jwt token used for authenticating kubernetes requests
             token: K8S_TOKEN
             jobsNamespace: K8S_JOBS_NAMESPACE

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -34,6 +34,8 @@ executor:
       kubernetes:
         # The host or IP of the kubernetes cluster
         host: kubernetes.default
+        # Privileged mode, default restricted, set to true for trusted container runtime use-case
+        privileged: false
         dockerFeatureEnabled: false
         resources:
           cpu:
@@ -56,6 +58,8 @@ executor:
         nodeSelectors: {}
         preferredNodeSelectors: {}
         annotations: {}
+        # support for kata-containers-as-a-runtimeclass
+        runtimeClass: ""
       # Launcher image to use
       launchImage: screwdrivercd/launcher
       # Container tags to use
@@ -76,6 +80,8 @@ executor:
       kubernetes:
         # The host or IP of the kubernetes cluster
         host: kubernetes.default
+        # Privileged mode, default restricted, set to true for trusted container runtime use-case
+        privileged: false
         # Resources for build pod
         resources:
           cpu:


### PR DESCRIPTION
## Context
We want to use kata in the environment without using buildcluster-queue-worker.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Add `executor.k8s.options.kubernetes.privileged` to config files
- Add `executor.k8s.options.kubernetes.runtimeClass` to config files
- Add `executor.k8s-vm.options.kubernetes.privileged` to config files
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/818
https://github.com/screwdriver-cd/buildcluster-queue-worker/pull/48
https://github.com/screwdriver-cd/buildcluster-queue-worker/pull/53
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
