### PR TITLE
fix(2240): Convert SCHEDULER_ENABLED value from string to boolean.

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -253,7 +253,9 @@ worker:
 # Run queue-worker as a scheduler, instead of calling executor to start/stop builds, push it to rabbitmq
 scheduler:
     # Enabled schduler mode or not
-    enabled: SCHEDULER_ENABLED
+    enabled:
+        __name: SCHEDULER_ENABLED
+	__format: boolean
     # To enable schduler mode, you need rabbitmq server and consumer
     rabbitmq:
         # Host of rabbitmq cluster

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -253,9 +253,7 @@ worker:
 # Run queue-worker as a scheduler, instead of calling executor to start/stop builds, push it to rabbitmq
 scheduler:
     # Enabled schduler mode or not
-    enabled:
-        __name: SCHEDULER_ENABLED
-        __format: boolean
+    enabled: SCHEDULER_ENABLED
     # To enable schduler mode, you need rabbitmq server and consumer
     rabbitmq:
         # Host of rabbitmq cluster

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -255,7 +255,7 @@ scheduler:
     # Enabled schduler mode or not
     enabled:
         __name: SCHEDULER_ENABLED
-	__format: boolean
+        __format: boolean
     # To enable schduler mode, you need rabbitmq server and consumer
     rabbitmq:
         # Host of rabbitmq cluster

--- a/config/rabbitmq.js
+++ b/config/rabbitmq.js
@@ -13,7 +13,7 @@ function convertToBool(value) {
         return value;
     }
 
-    return String(value).toLowerCase() === 'true';
+    return value === 'true';
 }
 
 const rabbitmqConfig = config.get('scheduler').rabbitmq;

--- a/config/rabbitmq.js
+++ b/config/rabbitmq.js
@@ -2,10 +2,24 @@
 
 const config = require('config');
 
+/**
+ * convert value to Boolean
+ * @method convertToBool
+ * @param {(Boolean|String)} value
+ * @return {Boolean}
+ */
+function convertToBool(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    return value === 'true';
+}
+
 const rabbitmqConfig = config.get('scheduler').rabbitmq;
 const { protocol, username, password, host, port, exchange, vhost, connectOptions } = rabbitmqConfig;
 const amqpURI = `${protocol}://${username}:${password}@${host}:${port}${vhost}`;
-const schedulerMode = config.get('scheduler').enabled;
+const schedulerMode = convertToBool(config.get('scheduler').enabled);
 
 /**
  * get configurations for rabbitmq

--- a/config/rabbitmq.js
+++ b/config/rabbitmq.js
@@ -2,24 +2,10 @@
 
 const config = require('config');
 
-/**
- * convert value to Boolean
- * @method convertToBool
- * @param {(Boolean|String)} value
- * @return {Boolean}
- */
-function convertToBool(value) {
-    if (typeof value === 'boolean') {
-        return value;
-    }
-
-    return value === 'true';
-}
-
 const rabbitmqConfig = config.get('scheduler').rabbitmq;
 const { protocol, username, password, host, port, exchange, vhost, connectOptions } = rabbitmqConfig;
 const amqpURI = `${protocol}://${username}:${password}@${host}:${port}${vhost}`;
-const schedulerMode = convertToBool(config.get('scheduler').enabled);
+const schedulerMode = config.get('scheduler').enabled;
 
 /**
  * get configurations for rabbitmq

--- a/config/rabbitmq.js
+++ b/config/rabbitmq.js
@@ -13,7 +13,11 @@ function convertToBool(value) {
         return value;
     }
 
-    return String(value).toLowerCase() === 'true';
+    // trueList refers to https://yaml.org/type/bool.html
+    const trueList = ['on', 'true', 'yes', 'y'];
+    const lowerValue = String(value).toLowerCase();
+
+    return trueList.includes(lowerValue);
 }
 
 const rabbitmqConfig = config.get('scheduler').rabbitmq;

--- a/config/rabbitmq.js
+++ b/config/rabbitmq.js
@@ -13,7 +13,7 @@ function convertToBool(value) {
         return value;
     }
 
-    return value === 'true';
+    return String(value).toLowerCase() === 'true';
 }
 
 const rabbitmqConfig = config.get('scheduler').rabbitmq;

--- a/config/rabbitmq.js
+++ b/config/rabbitmq.js
@@ -2,10 +2,24 @@
 
 const config = require('config');
 
+/**
+ * convert value to Boolean
+ * @method convertToBool
+ * @param {(Boolean|String)} value
+ * @return {Boolean}
+ */
+function convertToBool(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    return String(value).toLowerCase() === 'true';
+}
+
 const rabbitmqConfig = config.get('scheduler').rabbitmq;
 const { protocol, username, password, host, port, exchange, vhost, connectOptions } = rabbitmqConfig;
 const amqpURI = `${protocol}://${username}:${password}@${host}:${port}${vhost}`;
-const schedulerMode = config.get('scheduler').enabled;
+const schedulerMode = convertToBool(config.get('scheduler').enabled);
 
 /**
  * get configurations for rabbitmq


### PR DESCRIPTION
## Context
Kubernetes can not set boolean values as environment variables. 
So, we can not switch on/off by using `SCHEDULER_ENABLED` environment variable.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Convert `SCHEDULER_ENABLED` value from string to boolean.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
Related Issue:
https://github.com/screwdriver-cd/screwdriver/issues/2240

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
