### PR TITLE
fix(2442): Remove exit(1)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -119,5 +119,4 @@ module.exports = async config => {
 
 process.on('unhandledRejection', err => {
     logger.error('Unhandled error: %s', err.stack ? err.stack : err);
-    process.exit(1);
 });


### PR DESCRIPTION
## Context
Fixes https://github.com/screwdriver-cd/screwdriver/issues/2442
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
When unhandledRejection occurred, we want to output error logs, but not call `process.exit(1)`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
