### PR TITLE
fix(2503): Properly handling when failing update build status

### DIFF
--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -63,8 +63,13 @@ async function updateBuildStatus(updateConfig) {
                 statusMessage
             }),
             (err, res) => {
-                if (!err && res.statusCode === 200) {
-                    return resolve(res.body);
+                if (!err) {
+                    if (res.statusCode === 200) {
+                        return resolve(res.body);
+                    }
+                    logger.error(`PUT /v4/builds/${buildId} returned non 200, ${res.statusCode}, ${res.body}`);
+
+                    return reject(new Error(`Failed to updateBuildStatus with ${res.statusCode} code and ${res.body}`));
                 }
 
                 return reject(err);

--- a/plugins/worker/lib/BlockedBy.js
+++ b/plugins/worker/lib/BlockedBy.js
@@ -3,7 +3,7 @@
 const NodeResque = require('node-resque');
 const hoek = require('@hapi/hoek');
 const logger = require('screwdriver-logger');
-const helper = require('../../helper.js');
+const helper = require('../../helper');
 const { runningJobsPrefix, waitingJobsPrefix, queuePrefix } = require('../../../config/redis');
 const BLOCK_TIMEOUT_BUFFER = 30;
 

--- a/plugins/worker/lib/BlockedBy.js
+++ b/plugins/worker/lib/BlockedBy.js
@@ -41,12 +41,16 @@ async function collapseBuilds({ waitingKey, buildId, blockingBuildIds }) {
 
             // if the build is no longer in the waiting queue, don't collapse it
             if (count > 0) {
-                await helper.updateBuildStatus({
-                    redisInstance: this.queueObject.connection.redis,
-                    buildId: bId,
-                    status: 'COLLAPSED',
-                    statusMessage: `Collapsed to build: ${buildId}`
-                });
+                await helper
+                    .updateBuildStatus({
+                        redisInstance: this.queueObject.connection.redis,
+                        buildId: bId,
+                        status: 'COLLAPSED',
+                        statusMessage: `Collapsed to build: ${buildId}`
+                    })
+                    .catch(err => {
+                        logger.error(`Failed to update build status to COLLAPSED for build:${bId}:${err}`);
+                    });
                 await this.queueObject.connection.redis.hdel(`${queuePrefix}buildConfigs`, bId);
             }
         });
@@ -203,12 +207,16 @@ class BlockedBy extends NodeResque.Plugin {
         // Current build is older than last running build for the same job, discard the build
         if (collapse && buildId < parseInt(lastRunningBuildId, 10)) {
             await this.queueObject.connection.redis.lrem(waitingKey, 0, buildId);
-            await helper.updateBuildStatus({
-                redisInstance: this.queueObject.connection.redis,
-                buildId,
-                status: 'COLLAPSED',
-                statusMessage: `Collapsed to build: ${lastRunningBuildId}`
-            });
+            await helper
+                .updateBuildStatus({
+                    redisInstance: this.queueObject.connection.redis,
+                    buildId,
+                    status: 'COLLAPSED',
+                    statusMessage: `Collapsed to build: ${lastRunningBuildId}`
+                })
+                .catch(err => {
+                    logger.error(`Failed to update build status to COLLAPSED for build:${buildId}:${err}`);
+                });
             await this.queueObject.connection.redis.hdel(`${queuePrefix}buildConfigs`, buildId);
 
             logger.info('%s | %s | Remove waiting key and collapse build', buildId, jobId);
@@ -354,12 +362,16 @@ class BlockedBy extends NodeResque.Plugin {
         // enqueueIn uses milliseconds
         await this.queueObject.enqueueIn(this.reenqueueWaitTime() * 1000 * 60, this.queue, this.func, this.args);
 
-        await helper.updateBuildStatus({
-            redisInstance: this.queueObject.connection.redis,
-            buildId,
-            status: 'BLOCKED',
-            statusMessage
-        });
+        await helper
+            .updateBuildStatus({
+                redisInstance: this.queueObject.connection.redis,
+                buildId,
+                status: 'BLOCKED',
+                statusMessage
+            })
+            .catch(err => {
+                logger.error(`Failed to update build status to BLOCKED for build:${buildId}:${err}`);
+            });
     }
 
     blockTimeout(buildTimeout) {

--- a/plugins/worker/lib/timeout.js
+++ b/plugins/worker/lib/timeout.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const logger = require('screwdriver-logger');
-const helper = require('../../helper.js');
+const helper = require('../../helper');
 const { waitingJobsPrefix, runningJobsPrefix, queuePrefix } = require('../../../config/redis');
 const TIMEOUT_CODE = 3;
 const TIMEOUT_BUFFER = 1;

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -81,6 +81,21 @@ describe('Helper Test', () => {
         assert.calledWith(mockRequest, requestOptions);
     });
 
+    it('logs correct message when fail to update build status with non 200 API response', async () => {
+        mockRequest.yieldsAsync(null, { statusCode: 401, body: 'Unauthorized' });
+        try {
+            await helper.updateBuildStatus({
+                redisInstance: mockRedis,
+                status,
+                statusMessage,
+                buildId: 1
+            });
+        } catch (err) {
+            assert.calledWith(mockRequest, requestOptions);
+            assert.strictEqual(err.message, 'Failed to updateBuildStatus with 401 code and Unauthorized');
+        }
+    });
+
     it('logs correct message when fail to update build failure status', async () => {
         const requestErr = new Error('failed to update');
         const response = {};

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -52,7 +52,7 @@ describe('Helper Test', () => {
         mockery.registerMock('../config/redis', mockRedisConfig);
 
         // eslint-disable-next-line global-require
-        helper = require('../../plugins/helper.js');
+        helper = require('../../plugins/helper');
     });
 
     afterEach(() => {

--- a/test/plugins/queue/index.test.js
+++ b/test/plugins/queue/index.test.js
@@ -46,7 +46,7 @@ describe('queue plugin test', () => {
         generateTokenMock = sinon.stub();
 
         /* eslint-disable global-require */
-        plugin = require('../../../plugins/queue/index.js');
+        plugin = require('../../../plugins/queue/index');
         /* eslint-enable global-require */
         server = new hapi.Server({
             port: 1234

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -126,7 +126,7 @@ describe('scheduler test', () => {
         mockery.registerMock('../helper', helperMock);
 
         /* eslint-disable global-require */
-        scheduler = require('../../../plugins/queue/scheduler.js');
+        scheduler = require('../../../plugins/queue/scheduler');
         Executor = require('../../../lib/queue');
         /* eslint-enable global-require */
 
@@ -535,7 +535,7 @@ describe('scheduler test', () => {
             mockery.registerMock('./utils/freezeWindows', freezeWindowsMockB);
 
             /* eslint-disable global-require */
-            scheduler = require('../../../plugins/queue/scheduler.js');
+            scheduler = require('../../../plugins/queue/scheduler');
             Executor = require('../../../lib/queue');
             /* eslint-enable global-require */
 

--- a/test/plugins/queue/stats.test.js
+++ b/test/plugins/queue/stats.test.js
@@ -23,7 +23,7 @@ describe('queue plugin test', () => {
         generateTokenMock = sinon.stub();
 
         /* eslint-disable global-require */
-        plugin = require('../../../plugins/queue/index.js');
+        plugin = require('../../../plugins/queue/index');
         /* eslint-enable global-require */
         server = new hapi.Server({
             port: 1234

--- a/test/plugins/queue/utils/cron.test.js
+++ b/test/plugins/queue/utils/cron.test.js
@@ -2,7 +2,7 @@
 
 const { assert } = require('chai');
 const hash = require('string-hash');
-const cron = require('../../../../plugins/queue/utils/cron.js');
+const cron = require('../../../../plugins/queue/utils/cron');
 
 const evaluateHash = (jobId, min, max) => (hash(jobId) % (max + 1 - min)) + min;
 

--- a/test/plugins/queue/utils/freezeWindows.test.js
+++ b/test/plugins/queue/utils/freezeWindows.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const { timeOutOfWindows } = require('../../../../plugins/queue/utils/freezeWindows.js');
+const { timeOutOfWindows } = require('../../../../plugins/queue/utils/freezeWindows');
 
 describe('freeze windows', () => {
     it('should return the correct date outside the freeze windows', () => {

--- a/test/plugins/worker/create.test.js
+++ b/test/plugins/worker/create.test.js
@@ -55,7 +55,7 @@ describe('POST /queue/worker', () => {
         generateTokenMock = sinon.stub();
 
         /* eslint-disable global-require */
-        const plugin = require('../../../plugins/worker/index.js');
+        const plugin = require('../../../plugins/worker/index');
         /* eslint-enable global-require */
 
         server.auth.scheme('custom', () => ({

--- a/test/plugins/worker/lib/BlockedBy.test.js
+++ b/test/plugins/worker/lib/BlockedBy.test.js
@@ -717,7 +717,7 @@ describe('Plugin Test', () => {
                 assert.calledWith(mockWorker.queueObject.enqueueIn, 300000, mockQueue, mockFunc, mockArgs);
             });
 
-            it('anyway collapse waiting builds to latest one and re-enqueue if blocked when updateBuildStatus error', async () => {
+            it('always collapse waiting builds to latest one and re-enqueue if blocked when updateBuildStatus error', async () => {
                 blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
                     blockedBySelf: true,
                     collapse: true

--- a/test/plugins/worker/lib/BlockedBy.test.js
+++ b/test/plugins/worker/lib/BlockedBy.test.js
@@ -716,6 +716,57 @@ describe('Plugin Test', () => {
                 await blockedBy.beforePerform();
                 assert.calledWith(mockWorker.queueObject.enqueueIn, 300000, mockQueue, mockFunc, mockArgs);
             });
+
+            it('handle error when collapse build process', async () => {
+                blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
+                    blockedBySelf: true,
+                    collapse: true
+                });
+                mockRedis.get.withArgs(`${runningJobsPrefix}111`).resolves('123');
+                mockRedis.get.withArgs(`last_${runningKey}`).resolves('4');
+                helperMock.updateBuildStatus.rejects();
+                await blockedBy.beforePerform();
+                assert.equal(mockRedis.get.getCall(0).args[0], deleteKey);
+                assert.equal(mockRedis.get.getCall(1).args[0], runningKey);
+                assert.equal(mockRedis.get.getCall(2).args[0], `last_${runningKey}`);
+                assert.notCalled(mockRedis.set);
+                assert.notCalled(mockRedis.expire);
+                assert.notCalled(mockWorker.queueObject.enqueueIn);
+                assert.calledOnce(mockRedis.lrem);
+                assert.calledWith(helperMock.updateBuildStatus, {
+                    buildId: 3,
+                    redisInstance: mockRedis,
+                    status: 'COLLAPSED',
+                    statusMessage: 'Collapsed to build: 4'
+                });
+            });
+
+            it('handle error when re-enqueue process', async () => {
+                mockRedis.get.withArgs(`${runningJobsPrefix}111`).resolves('123');
+                helperMock.updateBuildStatus.rejects();
+                await blockedBy.beforePerform();
+                assert.equal(mockRedis.get.getCall(0).args[0], deleteKey);
+                assert.equal(mockRedis.get.getCall(1).args[0], runningKey);
+                assert.equal(mockRedis.get.getCall(2).args[0], `last_${runningKey}`);
+                assert.equal(mockRedis.get.getCall(3).args[0], `${runningJobsPrefix}111`);
+                assert.equal(mockRedis.get.getCall(4).args[0], `${runningJobsPrefix}222`);
+                assert.notCalled(mockRedis.set);
+                assert.notCalled(mockRedis.expire);
+                assert.calledWith(mockRedis.rpush, `${waitingJobsPrefix}${jobId}`, buildId);
+                assert.calledWith(
+                    mockWorker.queueObject.enqueueIn,
+                    DEFAULT_ENQUEUETIME * 1000 * 60,
+                    mockQueue,
+                    mockFunc,
+                    mockArgs
+                );
+                assert.calledWith(helperMock.updateBuildStatus, {
+                    buildId: 3,
+                    redisInstance: mockRedis,
+                    status: 'BLOCKED',
+                    statusMessage: 'Blocked by these running build(s): <a href="/builds/123">123</a>'
+                });
+            });
         });
 
         describe('afterPerform', () => {

--- a/test/plugins/worker/lib/BlockedBy.test.js
+++ b/test/plugins/worker/lib/BlockedBy.test.js
@@ -77,7 +77,7 @@ describe('Plugin Test', () => {
 
         mockery.registerMock('ioredis', mockRedis);
         mockery.registerMock('../../../config/redis', mockRedisConfig);
-        mockery.registerMock('../../helper.js', helperMock);
+        mockery.registerMock('../../helper', helperMock);
 
         // eslint-disable-next-line global-require
         BlockedBy = require('../../../../plugins/worker/lib/BlockedBy').BlockedBy;

--- a/test/plugins/worker/lib/BlockedBy.test.js
+++ b/test/plugins/worker/lib/BlockedBy.test.js
@@ -717,7 +717,52 @@ describe('Plugin Test', () => {
                 assert.calledWith(mockWorker.queueObject.enqueueIn, 300000, mockQueue, mockFunc, mockArgs);
             });
 
-            it('handle error when collapse build process', async () => {
+            it('anyway collapse waiting builds to latest one and re-enqueue if blocked when updateBuildStatus error', async () => {
+                blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
+                    blockedBySelf: true,
+                    collapse: true
+                });
+                mockRedis.get.withArgs(`${runningJobsPrefix}111`).resolves('123');
+                mockRedis.lrange.resolves(['2', '1']);
+                mockRedis.lrem.resolves(1);
+                helperMock.updateBuildStatus.rejects();
+                await blockedBy.beforePerform();
+                assert.equal(mockRedis.get.getCall(0).args[0], deleteKey);
+                assert.equal(mockRedis.get.getCall(1).args[0], runningKey);
+                assert.equal(mockRedis.get.getCall(2).args[0], `last_${runningKey}`);
+                assert.equal(mockRedis.get.getCall(3).args[0], `${runningJobsPrefix}111`);
+                assert.equal(mockRedis.get.getCall(4).args[0], `${runningJobsPrefix}222`);
+                assert.notCalled(mockRedis.set);
+                assert.notCalled(mockRedis.expire);
+                assert.calledWith(mockRedis.rpush, `${waitingJobsPrefix}${jobId}`, buildId);
+                assert.calledWith(
+                    mockWorker.queueObject.enqueueIn,
+                    DEFAULT_ENQUEUETIME * 1000 * 60,
+                    mockQueue,
+                    mockFunc,
+                    mockArgs
+                );
+                assert.calledWith(helperMock.updateBuildStatus.firstCall, {
+                    buildId: 1,
+                    redisInstance: mockRedis,
+                    status: 'COLLAPSED',
+                    statusMessage: 'Collapsed to build: 3'
+                });
+                assert.calledWith(helperMock.updateBuildStatus.secondCall, {
+                    buildId: 2,
+                    redisInstance: mockRedis,
+                    status: 'COLLAPSED',
+                    statusMessage: 'Collapsed to build: 3'
+                });
+                assert.calledWith(helperMock.updateBuildStatus.thirdCall, {
+                    buildId,
+                    redisInstance: mockRedis,
+                    status: 'BLOCKED',
+                    statusMessage: 'Blocked by these running build(s): <a href="/builds/123">123</a>'
+                });
+            });
+
+            it('anyway collapse and discard build if older than last running build when updateBuildStatus error', async () => {
                 blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
                     blockedBySelf: true,
                     collapse: true
@@ -741,7 +786,7 @@ describe('Plugin Test', () => {
                 });
             });
 
-            it('handle error when re-enqueue process', async () => {
+            it('anyway re-enqueue if blocked when updateBuildStatus error', async () => {
                 mockRedis.get.withArgs(`${runningJobsPrefix}111`).resolves('123');
                 helperMock.updateBuildStatus.rejects();
                 await blockedBy.beforePerform();

--- a/test/plugins/worker/lib/BlockedBy.test.js
+++ b/test/plugins/worker/lib/BlockedBy.test.js
@@ -595,6 +595,7 @@ describe('Plugin Test', () => {
             it('re-enqueue if blocked and not push to list if duplicate', async () => {
                 mockRedis.get.withArgs(`${runningJobsPrefix}111`).resolves('123');
                 mockRedis.lrange.resolves([buildIdStr]);
+                helperMock.updateBuildStatus.resolves();
                 await blockedBy.beforePerform();
                 assert.equal(mockRedis.get.getCall(0).args[0], deleteKey);
                 assert.equal(mockRedis.get.getCall(1).args[0], runningKey);
@@ -636,6 +637,7 @@ describe('Plugin Test', () => {
             it('re-enqueue if there is the same job waiting but not the same buildId', async () => {
                 mockRedis.lrange.resolves(['2']);
                 mockRedis.llen.resolves(1);
+                helperMock.updateBuildStatus.resolves();
                 await blockedBy.beforePerform();
                 assert.equal(mockRedis.get.getCall(0).args[0], deleteKey);
                 assert.equal(mockRedis.get.getCall(1).args[0], runningKey);
@@ -706,6 +708,7 @@ describe('Plugin Test', () => {
                 const reenqueueWaitTime = 5;
 
                 mockRedis.get.withArgs(`${runningJobsPrefix}111`).resolves('123');
+                helperMock.updateBuildStatus.resolves();
                 blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
                     reenqueueWaitTime
                 });

--- a/test/plugins/worker/lib/cacheFilter.test.js
+++ b/test/plugins/worker/lib/cacheFilter.test.js
@@ -69,7 +69,7 @@ describe('CacheFilter Plugin Test', () => {
         mockery.registerMock('ioredis', mockRedis);
 
         // eslint-disable-next-line global-require
-        CacheFilter = require('../../../../plugins/worker/lib/CacheFilter.js').CacheFilter;
+        CacheFilter = require('../../../../plugins/worker/lib/CacheFilter').CacheFilter;
 
         filter = new CacheFilter(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {});
     });

--- a/test/plugins/worker/lib/filter.test.js
+++ b/test/plugins/worker/lib/filter.test.js
@@ -69,7 +69,7 @@ describe('Plugin Test', () => {
         mockery.registerMock('ioredis', mockRedis);
 
         // eslint-disable-next-line global-require
-        Filter = require('../../../../plugins/worker/lib/Filter.js').Filter;
+        Filter = require('../../../../plugins/worker/lib/Filter').Filter;
 
         filter = new Filter(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {});
     });

--- a/test/plugins/worker/lib/timeout.test.js
+++ b/test/plugins/worker/lib/timeout.test.js
@@ -60,10 +60,10 @@ describe('Timeout test', () => {
         };
 
         mockery.registerMock('../../../config/redis', mockRedisConfig);
-        mockery.registerMock('../../helper.js', helperMock);
+        mockery.registerMock('../../helper', helperMock);
 
         // eslint-disable-next-line global-require
-        timeout = require('../../../../plugins/worker/lib/timeout.js');
+        timeout = require('../../../../plugins/worker/lib/timeout');
     });
 
     afterEach(() => {

--- a/test/plugins/worker/worker.test.js
+++ b/test/plugins/worker/worker.test.js
@@ -135,7 +135,7 @@ describe('Schedule test', () => {
         configMock.get.withArgs('worker').returns(workerConfig);
 
         // eslint-disable-next-line global-require
-        workerObj = require('../../../plugins/worker/worker.js');
+        workerObj = require('../../../plugins/worker/worker');
         testWorker = workerObj.multiWorker;
         testScheduler = workerObj.scheduler;
         workerObj.invoke();


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When queue-service tries to update the build state and receives an err from the API, queue-service should not be restarted.
However, currently, the queue-service will be restarted with unhandledRejection when receives an err from the API.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add error handling method when updating buildStatus.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2503

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
