### PR TITLE
[2] fix(2096): Pass QUEUED status when start builds

### DIFF
--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -396,7 +396,7 @@ async function start(executor, config) {
                     buildId,
                     token: buildToken,
                     apiUri,
-                    payload: { stats: build.stats }
+                    payload: { stats: build.stats, status: 'QUEUED' }
                 },
                 executor.requestRetryStrategy
             );

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -381,7 +381,7 @@ describe('scheduler test', () => {
                         buildId,
                         token: 'buildToken',
                         apiUri: 'http://api.com',
-                        payload: { stats: buildMock.stats }
+                        payload: { stats: buildMock.stats, status: 'QUEUED' }
                     },
                     executor.requestRetryStrategy
                 );
@@ -481,7 +481,7 @@ describe('scheduler test', () => {
                         buildId,
                         token: 'buildToken',
                         apiUri: 'http://api.com',
-                        payload: { stats: buildMock.stats }
+                        payload: { stats: buildMock.stats, status: 'QUEUED' }
                     },
                     executor.requestRetryStrategy
                 );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We should send QUEUED status when start build so that QUEUED notifications only sent once.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Queue-service updates build with `status: 'QUEUED'` when start build.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

issues: screwdriver-cd/screwdriver#2096

API fix: https://github.com/screwdriver-cd/screwdriver/pull/2512

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
