### PR TITLE
fix(1961): Retry with new request package

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -56,16 +56,16 @@ module.exports = class ExecutorQueue {
                 this.redis[funcName](...args),
             breakerOptions
         );
-        this.requestRetryStrategy = (response, retryWithMergedOptions) => {
+        this.requestRetryStrategy = response => {
             if (Math.floor(response.statusCode / 100) !== 2) {
-                retryWithMergedOptions({});
+                throw new Error('Retry limit reached');
             }
 
             return response;
         };
-        this.requestRetryStrategyPostEvent = (response, retryWithMergedOptions) => {
+        this.requestRetryStrategyPostEvent = response => {
             if (Math.floor(response.statusCode / 100) !== 2 && response.statusCode !== 404) {
-                retryWithMergedOptions({});
+                throw new Error('Retry limit reached');
             }
 
             return response;

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -28,19 +28,19 @@ function formatOptions(method, url, token, json, retryStrategyFn) {
         Object.assign(options, { json });
     }
     if (retryStrategyFn) {
-        const retryOptions = {
+        const retry = {
             limit: RETRY_LIMIT,
             calculateDelay: ({ computedValue }) => (computedValue ? RETRY_DELAY * 1000 : 0) // in ms
         };
 
         if (method === 'POST') {
-            Object.assign(retryOptions, {
+            Object.assign(retry, {
                 methods: ['POST']
             });
         }
 
         Object.assign(options, {
-            retryOptions,
+            retry,
             hooks: {
                 afterResponse: [retryStrategyFn]
             }

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -244,7 +244,7 @@ describe('Helper Test', () => {
                     Authorization: 'Bearer fake'
                 },
                 json: { buildId: 1, eventId: 321, jobId: 123 },
-                retryOptions: {
+                retry: {
                     limit: 3,
                     methods: ['POST']
                 }
@@ -271,7 +271,7 @@ describe('Helper Test', () => {
                     Authorization: 'Bearer fake'
                 },
                 json: { buildId: 1, eventId: 321, jobId: 123 },
-                retryOptions: {
+                retry: {
                     limit: 3,
                     methods: ['POST']
                 },
@@ -302,7 +302,7 @@ describe('Helper Test', () => {
                     Authorization: 'Bearer fake'
                 },
                 json: { buildId: 1, eventId: 321, jobId: 123 },
-                retryOptions: {
+                retry: {
                     limit: 3,
                     methods: ['POST']
                 },
@@ -334,7 +334,7 @@ describe('Helper Test', () => {
                 headers: {
                     Authorization: 'Bearer fake'
                 },
-                retryOptions: {
+                retry: {
                     limit: 3
                 },
                 hooks: { afterResponse: [retryFn] }
@@ -365,7 +365,7 @@ describe('Helper Test', () => {
                 headers: {
                     Authorization: 'Bearer fake'
                 },
-                retryOptions: {
+                retry: {
                     limit: 3
                 },
                 hooks: { afterResponse: [retryFn] }
@@ -395,7 +395,7 @@ describe('Helper Test', () => {
                 headers: {
                     Authorization: 'Bearer fake'
                 },
-                retryOptions: {
+                retry: {
                     limit: 3
                 },
                 hooks: { afterResponse: [retryFn] }
@@ -434,7 +434,7 @@ describe('Helper Test', () => {
                     Authorization: 'Bearer fake'
                 },
                 json: { status, statusMessage },
-                retryOptions: {
+                retry: {
                     limit: 3
                 },
                 hooks: { afterResponse: [retryFn] }
@@ -476,7 +476,7 @@ describe('Helper Test', () => {
                     Authorization: 'Bearer fake'
                 },
                 json: { status, statusMessage },
-                retryOptions: {
+                retry: {
                     limit: 3
                 },
                 hooks: { afterResponse: [retryFn] }


### PR DESCRIPTION
## Context

Retry is not working as expected.

## Objective

This PR:
- renames from `retryOptions` => `retry`
- throws error in retry strategy in `afterResponse` hook to correctly trigger retries

## References

Related to https://github.com/screwdriver-cd/queue-service/pull/33

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
