### PR TITLE
feat(#2559): integrate producer-svc with queuesvc

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -272,3 +272,22 @@ scheduler:
         vhost: RABBITMQ_VHOST
         # Connection options
         connectOptions: RABBITMQ_CONNECT_OPTIONS
+kafka:
+  # flag for kafka broker
+  enabled: KAFKA_ENABLED
+  # kafka brokers list
+  hosts: KAFKA_BROKERS_LIST
+  # sasl options
+  sasl:
+    # sasl mechanism
+    mechanism: SASL_MECHANISM
+    # secret id for sasl/scram
+    secretId: SASL_AWS_SECRET_ID
+  # client id of the producer
+  clientId: KAFKA_CLIENT_ID
+  # Amazon access key
+  accessKeyId: KAFKA_ACCESS_KEY_ID
+  # Amazon secret access key
+  secretAccessKey: KAFKA_ACCESS_KEY_SECRET
+  # AWS region 
+  region: AWS_REGION

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -202,3 +202,23 @@ scheduler:
     vhost: /screwdriver
     # Connect Options
     connectOptions: { json: true, heartbeatIntervalInSeconds: 20, reconnectTimeInSeconds: 30 }
+
+kafka:
+  # flag for kafka broker
+  enabled: false
+  # kafka brokers list
+  hosts: KAFKA_BROKERS_LIST
+  # sasl options
+  sasl:
+    # sasl mechanism
+    mechanism: scram-sha-512
+    # secret id for sasl/scram
+    secretId: fake-secret
+  # client id of the producer
+  clientId: sd-producer
+  # Amazon access key
+  accessKeyId: KAFKA_ACCESS_KEY_ID
+  # Amazon secret access key
+  secretAccessKey: KAFKA_ACCESS_KEY_SECRET
+  # AWS region 
+  region: AWS_REGION

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "laabr": "^6.1.3",
     "node-resque": "^5.5.3",
     "redlock": "^4.2.0",
-    "screwdriver-data-schema": "^21.2.5",
+    "screwdriver-aws-producer-service": "^1.1.0",
+    "screwdriver-data-schema": "^21.10.2",
     "screwdriver-executor-docker": "^5.0.2",
     "screwdriver-executor-jenkins": "^5.0.1",
     "screwdriver-executor-k8s": "^14.14.4",
@@ -59,7 +60,8 @@
     "pretest": "eslint . --quiet",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
     "debug": "node --nolazy ./bin/server",
-    "functional": "cucumber-js --format=progress --tags 'not @ignore' --retry 2 --fail-fast --exit"
+    "functional": "cucumber-js --format=progress --tags 'not @ignore' --retry 2 --fail-fast --exit",
+    "semantic-release": "semantic-release"
   },
   "repository": {
     "type": "git",
@@ -84,9 +86,6 @@
   },
   "homepage": "https://github.com/screwdriver-cd/screwdriver-queue-service#readme",
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -651,7 +651,7 @@ async function stop(executor, config) {
 }
 
 /**
- * Cleanup any reladed processing
+ * Cleanup any related processing
  */
 async function cleanUp(executor) {
     try {

--- a/plugins/worker/lib/jobs.js
+++ b/plugins/worker/lib/jobs.js
@@ -208,8 +208,8 @@ async function start(buildConfig) {
  */
 async function stop(buildConfig) {
     const started = hoek.reach(buildConfig, 'started', { default: true }); // default value for backward compatibility
-    const { buildId, jobId } = buildConfig;
-    let stopConfig = { buildId };
+    const { buildId, jobId, jobName } = buildConfig;
+    let stopConfig = { buildId, jobId, jobName };
     const runningKey = `${runningJobsPrefix}${jobId}`;
 
     try {

--- a/plugins/worker/lib/jobs.js
+++ b/plugins/worker/lib/jobs.js
@@ -6,7 +6,7 @@ const config = require('config');
 const hoek = require('@hapi/hoek');
 const ExecutorRouter = require('screwdriver-executor-router');
 const logger = require('screwdriver-logger');
-const producer = require('screwdriver-aws-producer-service');
+const AWSProducer = require('screwdriver-aws-producer-service');
 const { BlockedBy } = require('./BlockedBy');
 const { Filter } = require('./Filter');
 const { CacheFilter } = require('./CacheFilter');
@@ -126,10 +126,10 @@ async function pushToRabbitMq(message, queue, messageId) {
  * @param {String} topic
  */
 async function pushToKafka(message, topic) {
-    const conn = await producer.connect();
+    const conn = await AWSProducer.connect();
 
     if (conn) {
-        await producer.sendMessage(message, topic);
+        await AWSProducer.sendMessage(message, topic);
     }
 }
 

--- a/test/data/executorConfig.json
+++ b/test/data/executorConfig.json
@@ -1,0 +1,86 @@
+{
+    "plugin": "k8s-vm",
+    "k8s": {
+        "options": {
+            "kubernetes": {
+                "host": "kubernetes.default",
+                "privileged": false,
+                "automountServiceAccountToken": false,
+                "dockerFeatureEnabled": false,
+                "resources": {
+                    "cpu": {
+                        "micro": "0.5",
+                        "low": 2,
+                        "high": 6,
+                        "turbo": 12
+                    },
+                    "memory": {
+                        "micro": 1,
+                        "low": 2,
+                        "high": 12,
+                        "turbo": 16
+                    }
+                },
+                "buildTimeout": 90,
+                "maxBuildTimeout": 120,
+                "podLabels": {},
+                "nodeSelectors": {},
+                "preferredNodeSelectors": {},
+                "annotations": {},
+                "runtimeClass": "",
+                "imagePullSecretName": ""
+            },
+            "launchImage": "screwdrivercd/launcher",
+            "launchVersion": "stable",
+            "fusebox": {
+                "breaker": {
+                    "timeout": 10000
+                }
+            },
+            "requestretry": {
+                "retryDelay": 3000,
+                "maxAttempts": 5
+            }
+        }
+    },
+    "k8s-vm": {
+        "options": {
+            "kubernetes": {
+                "host": "kubernetes.default",
+                "privileged": false,
+                "resources": {
+                    "cpu": {
+                        "micro": 1,
+                        "low": 2,
+                        "high": 6,
+                        "turbo": 12,
+                        "max": 12
+                    },
+                    "memory": {
+                        "micro": 1,
+                        "low": 2,
+                        "high": 12,
+                        "turbo": 16,
+                        "max": 16
+                    }
+                },
+                "buildTimeout": 90,
+                "maxBuildTimeout": 120,
+                "podLabels": {},
+                "nodeSelectors": {},
+                "preferredNodeSelectors": {}
+            },
+            "launchImage": "screwdrivercd/launcher",
+            "launchVersion": "stable",
+            "fusebox": {
+                "breaker": {
+                    "timeout": 10000
+                }
+            },
+            "requestretry": {
+                "retryDelay": 3000,
+                "maxAttempts": 5
+            }
+        }
+    }
+}

--- a/test/plugins/worker/lib/jobs.test.js
+++ b/test/plugins/worker/lib/jobs.test.js
@@ -308,7 +308,7 @@ describe('Jobs Unit Test', () => {
                     assert.fail('Should not get here');
                 },
                 err => {
-                    assert.calledOnce(mockRabbitmqCh.on);
+                    assert.calledWith(mockRabbitmqCh.on, 'error');
                     assert.calledOnce(mockRabbitmqCh.close);
                     assert.deepEqual(err, expectedError);
                 }
@@ -367,6 +367,7 @@ describe('Jobs Unit Test', () => {
                 assert.notCalled(mockExecutor.start);
                 assert.calledOnce(mockProducerSvc.connect);
                 assert.calledWith(mockProducerSvc.sendMessage, msg, topic);
+                assert.notCalled(mockRabbitmqCh.on);
             });
         });
 
@@ -494,6 +495,7 @@ describe('Jobs Unit Test', () => {
                 });
                 assert.calledOnce(mockRabbitmqCh.close);
                 assert.notCalled(mockExecutor.stop);
+                assert.calledWith(mockRabbitmqCh.on, 'error');
             });
         });
 
@@ -526,6 +528,7 @@ describe('Jobs Unit Test', () => {
                 assert.notCalled(mockExecutor.stop);
                 assert.calledOnce(mockProducerSvc.connect);
                 assert.calledWith(mockProducerSvc.sendMessage, msg, topic);
+                assert.notCalled(mockRabbitmqCh.on);
             });
         });
 

--- a/test/plugins/worker/lib/jobs.test.js
+++ b/test/plugins/worker/lib/jobs.test.js
@@ -3,12 +3,15 @@
 const { assert } = require('chai');
 const mockery = require('mockery');
 const sinon = require('sinon');
+const testExecutorConfig = require('../../../data/executorConfig.json');
+
 const fullConfig = {
     annotations: {
         'beta.screwdriver.cd/executor': 'k8s'
     },
     buildId: 8609,
     jobId: 777,
+    jobName: 'main',
     blockedBy: [777],
     container: 'node:4',
     apiUri: 'http://api.com',
@@ -17,8 +20,16 @@ const fullConfig = {
 const partialConfig = {
     buildId: 8609,
     jobId: 777,
+    jobName: 'main',
     blockedBy: [777]
 };
+const providerConfig = {
+    accountId: '123',
+    securityGroupId: 'sg-123',
+    subnetId: ['subnet-123', 'subnet-321'],
+    region: 'us-east-1'
+};
+const configWithProvider = { ...fullConfig, provider: providerConfig };
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -37,6 +48,10 @@ describe('Jobs Unit Test', () => {
     let mockRabbitmqConnection;
     let mockRabbitmqCh;
     let mockRedisConfig;
+    let mockKafkaConfig;
+    let mockConfig;
+    let mockProducerSvc;
+    let mockEcosystemConfig;
 
     before(() => {
         mockery.enable({
@@ -56,18 +71,20 @@ describe('Jobs Unit Test', () => {
             hdel: sinon.stub(),
             del: sinon.stub(),
             get: sinon.stub(),
-            lrem: sinon.stub().resolves()
+            lrem: sinon.stub()
         };
 
         mockRabbitmqCh = {
             publish: sinon.stub().resolves(null),
             assertExchange: sinon.stub().resolves(null),
-            close: sinon.stub().resolves(null)
+            close: sinon.stub().resolves(null),
+            on: sinon.stub()
         };
 
         mockRabbitmqConnection = {
             on: sinon.stub(),
-            createChannel: sinon.stub().returns(mockRabbitmqCh)
+            createChannel: sinon.stub().returns(mockRabbitmqCh),
+            close: sinon.stub().resolves(null)
         };
 
         mockAmqp = {
@@ -96,22 +113,56 @@ describe('Jobs Unit Test', () => {
             waitingJobsPrefix: 'waiting_job_'
         };
 
+        mockKafkaConfig = {
+            enabled: 'true',
+            region: 'us-east-1',
+            hosts: 'b-1.example.com:9096,b-2.example.com:9096',
+            sasl: {
+                mechanism: 'scram-sha-512',
+                secretId: 'AmazonMSK_BETA_SD_SECRET'
+            },
+            clientId: 'sd-producer'
+        };
+
         mockRabbitmqConfig = {
             getConfig: sinon.stub().returns(mockRabbitmqConfigObj)
+        };
+
+        mockConfig = {
+            get: sinon.stub().returns()
         };
 
         mockExecutorRouter = function() {
             return mockExecutor;
         };
-        mockery.registerMock('screwdriver-executor-router', mockExecutorRouter);
 
+        mockEcosystemConfig = {
+            ui: 'foo.ui',
+            api: 'foo.api',
+            store: 'foo.store',
+            cache: {
+                strategy: 's3',
+                path: '/',
+                compress: false,
+                md5check: false,
+                max_size_mb: 0
+            }
+        };
+
+        mockProducerSvc = {
+            connect: sinon.stub().resolves({}),
+            sendMessage: sinon.stub().resolves({})
+        };
+
+        mockery.registerMock('config', mockConfig);
+        mockery.registerMock('screwdriver-executor-router', mockExecutorRouter);
         mockery.registerMock('amqp-connection-manager', mockAmqp);
 
         mockRedis = sinon.stub().returns(mockRedisObj);
         mockery.registerMock('ioredis', mockRedis);
-
         mockery.registerMock('../../../config/rabbitmq', mockRabbitmqConfig);
         mockery.registerMock('../../../config/redis', mockRedisConfig);
+        mockery.registerMock('screwdriver-aws-producer-service', mockProducerSvc);
 
         mockBlockedBy = {
             BlockedBy: sinon.stub().returns()
@@ -127,6 +178,17 @@ describe('Jobs Unit Test', () => {
         mockery.registerMock('./Filter', mockFilter);
         mockery.registerMock('./CacheFilter', mockCacheFilter);
 
+        mockConfig.get.withArgs('kafka').returns(mockKafkaConfig);
+        mockConfig.get.withArgs('ecosystem').returns(mockEcosystemConfig);
+        mockConfig.get.withArgs('plugins').returns({
+            blockedBy: {
+                blockTimeout: 120,
+                reenqueueWaitTime: 1,
+                blockedBySelf: true,
+                collapse: true
+            }
+        });
+        mockConfig.get.withArgs('executor').returns(testExecutorConfig);
         // eslint-disable-next-line global-require
         jobs = require('../../../../plugins/worker/lib/jobs');
     });
@@ -153,7 +215,7 @@ describe('Jobs Unit Test', () => {
         });
     });
 
-    describe('start', () => {
+    describe('start', async () => {
         it('constructs start job correctly', () =>
             assert.deepEqual(jobs.start, {
                 plugins: [mockFilter.Filter, 'Retry', mockBlockedBy.BlockedBy],
@@ -184,7 +246,7 @@ describe('Jobs Unit Test', () => {
             });
         });
 
-        it('enqueus a start job with scheduler mode', () => {
+        it('enqueues a start job with scheduler mode', () => {
             mockRabbitmqConfigObj.schedulerMode = true;
             mockRabbitmqConfig.getConfig.returns(mockRabbitmqConfigObj);
             fullConfig.buildClusterName = 'sd';
@@ -263,6 +325,44 @@ describe('Jobs Unit Test', () => {
                 }
             );
         });
+        it('enqueues a start job to kafka queue when kafkaEnabled is true', async () => {
+            mockRedisObj.hget.resolves(JSON.stringify(configWithProvider));
+
+            return jobs.start.perform(configWithProvider).then(result => {
+                delete configWithProvider.buildClusterName;
+                const msg = {
+                    job: 'start',
+                    buildConfig: configWithProvider
+                };
+                const topic = `builds-${providerConfig.accountId}-${providerConfig.region}`;
+
+                assert.isNull(result);
+                assert.calledWith(mockRedisObj.hget, 'buildConfigs', configWithProvider.buildId);
+                assert.notCalled(mockAmqp.connect);
+                assert.notCalled(mockRabbitmqConnection.createChannel);
+                assert.notCalled(mockRabbitmqCh.publish);
+                assert.notCalled(mockExecutor.start);
+                assert.calledOnce(mockProducerSvc.connect);
+                assert.calledWith(mockProducerSvc.sendMessage, msg, topic);
+            });
+        });
+        it('enqueues a start job to rabbitMQ when kafka is enabled but provider config is not available', async () => {
+            mockRabbitmqConfigObj.schedulerMode = true;
+            mockRabbitmqConfig.getConfig.returns(mockRabbitmqConfigObj);
+            fullConfig.buildClusterName = 'sd';
+            mockRedisObj.hget.resolves(JSON.stringify(fullConfig));
+
+            return jobs.start.perform(fullConfig).then(result => {
+                assert.isNull(result);
+                assert.calledWith(mockRedisObj.hget, 'buildConfigs', fullConfig.buildId);
+                assert.calledOnce(mockAmqp.connect);
+                assert.calledOnce(mockRabbitmqConnection.createChannel);
+                assert.calledOnce(mockRabbitmqCh.publish);
+                assert.notCalled(mockExecutor.start);
+                assert.notCalled(mockProducerSvc.connect);
+                assert.notCalled(mockProducerSvc.sendMessage);
+            });
+        });
     });
 
     describe('stop', () => {
@@ -304,20 +404,25 @@ describe('Jobs Unit Test', () => {
             mockRedisObj.del.resolves(null);
             mockRedisObj.get.withArgs('running_job_777').resolves(fullConfig.buildId);
 
-            return jobs.stop.perform(partialConfig).then(result => {
+            return jobs.stop.perform(fullConfig).then(result => {
                 assert.isNull(result);
                 assert.calledWith(mockRedisObj.hget, 'buildConfigs', fullConfig.buildId);
                 assert.calledWith(mockRedisObj.hdel, 'buildConfigs', fullConfig.buildId);
                 assert.calledWith(mockRedisObj.del, 'running_job_777');
                 assert.calledWith(mockRedisObj.lrem, 'waiting_job_777', 0, fullConfig.buildId);
                 assert.calledWith(mockExecutor.stop, {
-                    annotations: fullConfig.annotations,
-                    buildId: fullConfig.buildId
+                    buildId: 8609,
+                    annotations: { 'beta.screwdriver.cd/executor': 'k8s' },
+                    jobId: 777,
+                    jobName: 'main',
+                    blockedBy: [777],
+                    container: 'node:4',
+                    apiUri: 'http://api.com'
                 });
             });
         });
 
-        it('enqueus a stop job with scheduler mode', () => {
+        it('enqueues a stop job with scheduler mode', () => {
             fullConfig.buildClusterName = 'sd';
             mockExecutor.stop.resolves(null);
             mockRedisObj.hget.resolves(JSON.stringify(fullConfig));
@@ -328,15 +433,11 @@ describe('Jobs Unit Test', () => {
             mockRabbitmqConfig.getConfig.returns(mockRabbitmqConfigObj);
             const { amqpURI, exchange, connectOptions } = mockRabbitmqConfigObj;
 
-            return jobs.stop.perform(partialConfig).then(result => {
+            return jobs.stop.perform(fullConfig).then(result => {
                 delete fullConfig.buildClusterName;
                 const msg = {
                     job: 'stop',
-                    buildConfig: {
-                        buildId: fullConfig.buildId,
-                        annotations: fullConfig.annotations,
-                        token: fullConfig.token
-                    }
+                    buildConfig: fullConfig
                 };
 
                 assert.isNull(result);
@@ -353,6 +454,38 @@ describe('Jobs Unit Test', () => {
                 });
                 assert.calledOnce(mockRabbitmqCh.close);
                 assert.notCalled(mockExecutor.stop);
+            });
+        });
+
+        it('enqueues a stop job to kafka queue when kafkaEnabled is true', () => {
+            mockExecutor.stop.resolves(null);
+            mockRedisObj.hget.resolves(JSON.stringify(configWithProvider));
+
+            mockRedisObj.hdel.resolves(1);
+            mockRedisObj.del.resolves(null);
+            mockRedisObj.get.withArgs('running_job_777').resolves(configWithProvider.buildId);
+
+            return jobs.stop.perform(configWithProvider).then(result => {
+                delete configWithProvider.buildClusterName;
+                const msg = {
+                    job: 'stop',
+                    buildConfig: configWithProvider
+                };
+                const topic = `builds-${providerConfig.accountId}-${providerConfig.region}`;
+
+                assert.isNull(result);
+                assert.calledWith(mockRedisObj.hget, 'buildConfigs', configWithProvider.buildId);
+                assert.calledWith(mockRedisObj.hdel, 'buildConfigs', configWithProvider.buildId);
+                assert.calledWith(mockRedisObj.del, 'running_job_777');
+                assert.calledWith(mockRedisObj.lrem, 'waiting_job_777', 0, configWithProvider.buildId);
+                assert.calledWith(mockRedisObj.hget, 'buildConfigs', configWithProvider.buildId);
+                assert.notCalled(mockAmqp.connect);
+                assert.notCalled(mockRabbitmqConnection.createChannel);
+                assert.notCalled(mockRabbitmqCh.publish);
+                assert.notCalled(mockRabbitmqCh.close);
+                assert.notCalled(mockExecutor.stop);
+                assert.calledOnce(mockProducerSvc.connect);
+                assert.calledWith(mockProducerSvc.sendMessage, msg, topic);
             });
         });
 
@@ -471,7 +604,7 @@ describe('Jobs Unit Test', () => {
             });
         });
 
-        it('publish to all rabbitmq queues specified in buildCLuster', () => {
+        it('publish to all rabbitmq queues specified in buildCluster', () => {
             const cacheConfig = {
                 id: 123,
                 resource: 'caches',
@@ -481,7 +614,7 @@ describe('Jobs Unit Test', () => {
             };
 
             return jobs.clear.perform(cacheConfig).then(result => {
-                assert.deepEqual(result, [null, null]);
+                assert.deepEqual(result, null);
                 assert.calledWith(mockRedisObj.hget, 'buildConfigs', cacheConfig.id);
                 assert.calledWith(mockAmqp.connect, [amqpURI], connectOptions);
                 assert.calledTwice(mockRabbitmqConnection.createChannel);

--- a/test/plugins/worker/lib/jobs.test.js
+++ b/test/plugins/worker/lib/jobs.test.js
@@ -288,6 +288,28 @@ describe('Jobs Unit Test', () => {
                 },
                 err => {
                     assert.calledOnce(mockRabbitmqCh.close);
+                    assert.calledOnce(mockRabbitmqConnection.close);
+                    assert.deepEqual(err, expectedError);
+                }
+            );
+        });
+
+        it('raise channelWrapper error and close the channel when publish fails', () => {
+            const expectedError = new Error('failed to publish');
+
+            mockRedisObj.hget.resolves(JSON.stringify(fullConfig));
+            mockRabbitmqConfigObj.schedulerMode = true;
+            mockRabbitmqConfig.getConfig.returns(mockRabbitmqConfigObj);
+            fullConfig.buildClusterName = 'sd';
+            mockRabbitmqCh.publish.rejects(expectedError);
+
+            return jobs.start.perform({}).then(
+                () => {
+                    assert.fail('Should not get here');
+                },
+                err => {
+                    assert.calledOnce(mockRabbitmqCh.on);
+                    assert.calledOnce(mockRabbitmqCh.close);
                     assert.deepEqual(err, expectedError);
                 }
             );


### PR DESCRIPTION
## Context

To enable Screwdriver AWS Integration we need to integrate the [aws-producer-service](https://github.com/screwdriver-cd/aws-producer-service) with the existing queuing service

## Objective

This PR adds `aws-producer-service` as a dependency and relays messages to the service for AWS executors

## References

https://github.com/screwdriver-cd/screwdriver/issues/2559
https://github.com/screwdriver-cd/screwdriver/issues/2550

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
