### PR TITLE
fix(1500): Make queue-service available for SD_ZIP_ARTIFACTS

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -34,6 +34,7 @@ module.exports = class ExecutorQueue {
         this.userTokenGen = null;
         this.timeoutQueue = `${this.prefix}timeoutConfigs`;
         this.cacheQueue = `${this.prefix}cache`;
+        this.unzipQueue = `${this.prefix}unzip`;
 
         const redisConnection = { ...config.redisConnection, pkg: 'ioredis' };
 

--- a/plugins/queue/put.js
+++ b/plugins/queue/put.js
@@ -33,6 +33,9 @@ module.exports = () => ({
                     case 'cache':
                         await scheduler.clearCache(executor, request.payload);
                         break;
+                    case 'unzip':
+                        await scheduler.unzipArtifacts(executor, request.payload);
+                        break;
                     default:
                         await scheduler.start(executor, request.payload);
                         break;

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -691,10 +691,11 @@ async function clearCache(executor, config) {
 
 /**
  * Pushes a message to unzip artifacts
- * @async unzipArtifacts
- * @param {Object} executor
- * @param {Object} config               Configuration
- * @param {String} config.buildId       Unique ID for a build
+ * @async  unzipArtifacts
+ * @param  {Object} executor
+ * @param  {Object} config               Configuration
+ * @param  {String} config.buildId       Unique ID for a build
+ * @return {Promise}
  */
 async function unzipArtifacts(executor, config) {
     await executor.connect();

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -13,6 +13,7 @@ const RETRY_LIMIT = 3;
 const RETRY_DELAY = 5;
 const EXPIRE_TIME = 1800; // 30 mins
 const TEMPORAL_TOKEN_TIMEOUT = 12 * 60; // 12 hours in minutes
+const TEMPORAL_UNZIP_TOKEN_TIMEOUT = 2 * 60; // 2 hours in minutes
 
 /**
  * Posts a new build event to the API
@@ -688,6 +689,32 @@ async function clearCache(executor, config) {
     }
 }
 
+/**
+ * Pushes a message to unzip artifacts
+ * @async unzipArtifacts
+ * @param {Object} executor
+ * @param {Object} config               Configuration
+ * @param {String} config.buildId       Unique ID for a build
+ */
+async function unzipArtifacts(executor, config) {
+    await executor.connect();
+    const { buildId } = config;
+    const tokenConfig = {
+        username: buildId,
+        scope: 'unzip_worker'
+    };
+    const token = executor.tokenGen(tokenConfig, TEMPORAL_UNZIP_TOKEN_TIMEOUT);
+
+    const enq = await executor.queueBreaker.runCommand('enqueue', executor.unzipQueue, 'start', [
+        {
+            buildId,
+            token
+        }
+    ]);
+
+    return enq;
+}
+
 module.exports = {
     init,
     start,
@@ -699,5 +726,6 @@ module.exports = {
     startTimer,
     stopTimer,
     cleanUp,
-    clearCache
+    clearCache,
+    unzipArtifacts
 };

--- a/test/lib/queue.test.js
+++ b/test/lib/queue.test.js
@@ -100,6 +100,7 @@ describe('queue test', () => {
             assert.strictEqual(executor.buildConfigTable, 'beta_buildConfigs');
             assert.strictEqual(executor.timeoutQueue, 'beta_timeoutConfigs');
             assert.strictEqual(executor.cacheQueue, 'beta_cache');
+            assert.strictEqual(executor.unzipQueue, 'beta_unzip');
         });
 
         it('throws when not given a redis connection', () => {

--- a/test/plugins/queue/index.test.js
+++ b/test/plugins/queue/index.test.js
@@ -37,7 +37,8 @@ describe('queue plugin test', () => {
             stopTimer: sinon.stub().resolves(),
             stopFrozen: sinon.stub().resolves(),
             stopPeriodic: sinon.stub().resolves(),
-            clearCache: sinon.stub().resolves()
+            clearCache: sinon.stub().resolves(),
+            unzipArtifacts: sinon.stub().resolves()
         };
 
         mockery.registerMock('./scheduler', schedulerMock);
@@ -235,6 +236,15 @@ describe('queue plugin test', () => {
 
             assert.equal(reply.statusCode, 200);
             assert.calledOnce(schedulerMock.startTimer);
+        });
+
+        it('returns 200 when deleting message from queue', async () => {
+            options.url = '/v1/queue/message?type=unzip';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.unzipArtifacts);
         });
     });
 });

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -884,10 +884,12 @@ describe('scheduler test', () => {
 
     describe('unzipArtifacts', () => {
         let unzipConfig;
+        let unzipConfigMsg;
 
         beforeEach(() => {
             executor.tokenGen.returns('unzipToken');
             unzipConfig = { buildId: 123 };
+            unzipConfigMsg = { buildId: 123, token: 'unzipToken' };
         });
 
         it("rejects if it can't establish a connection", function() {
@@ -913,14 +915,9 @@ describe('scheduler test', () => {
                         username: unzipConfig.buildId,
                         scope: 'unzip_worker'
                     },
-                    120
+                    TEMPORAL_UNZIP_TOKEN_TIMEOUT
                 );
-                assert.calledWith(queueMock.enqueue, 'unzip', 'start', [
-                    {
-                        buildId: 123,
-                        token: 'unzipToken'
-                    }
-                ]);
+                assert.calledWith(queueMock.enqueue, 'unzip', 'start', [unzipConfigMsg]);
             });
         });
 
@@ -938,12 +935,7 @@ describe('scheduler test', () => {
                     },
                     TEMPORAL_UNZIP_TOKEN_TIMEOUT
                 );
-                assert.calledWith(queueMock.enqueue, 'unzip', 'start', [
-                    {
-                        buildId: 123,
-                        token: 'unzipToken'
-                    }
-                ]);
+                assert.calledWith(queueMock.enqueue, 'unzip', 'start', [unzipConfigMsg]);
             });
         });
     });

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -905,7 +905,7 @@ describe('scheduler test', () => {
             );
         });
 
-        it('enqueues a unzip job', () => {
+        it('enqueues an unzip job', () => {
             return scheduler.unzipArtifacts(executor, unzipConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
                 assert.calledOnce(executor.tokenGen);


### PR DESCRIPTION
## Context
Implement `/v1/queue/message?type=unzip` endpoint for SD_ZIP_ARTIFACTS in order to make queue-service available to that function.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Create unzip queue for SD_ZIP_ARTIFACTS job
- Implements `scheduler.unzipArtifacts()`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1500
https://github.com/screwdriver-cd/screwdriver/pull/2583

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
