### PR TITLE
feat(1769): Add function to respond to request about webhook

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -30,6 +30,7 @@ module.exports = class ExecutorQueue {
         this.buildConfigTable = `${this.prefix}buildConfigs`;
         this.periodicBuildTable = `${this.prefix}periodicBuildConfigs`;
         this.frozenBuildTable = `${this.prefix}frozenBuildConfigs`;
+        this.webhookTable = `${this.prefix}webhooks`;
         this.tokenGen = null;
         this.userTokenGen = null;
         this.timeoutQueue = `${this.prefix}timeoutConfigs`;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -30,12 +30,12 @@ module.exports = class ExecutorQueue {
         this.buildConfigTable = `${this.prefix}buildConfigs`;
         this.periodicBuildTable = `${this.prefix}periodicBuildConfigs`;
         this.frozenBuildTable = `${this.prefix}frozenBuildConfigs`;
-        this.webhookTable = `${this.prefix}webhooks`;
         this.tokenGen = null;
         this.userTokenGen = null;
         this.timeoutQueue = `${this.prefix}timeoutConfigs`;
         this.cacheQueue = `${this.prefix}cache`;
         this.unzipQueue = `${this.prefix}unzip`;
+        this.webhookQueue = `${this.prefix}webhooks`;
 
         const redisConnection = { ...config.redisConnection, pkg: 'ioredis' };
 

--- a/plugins/queue/put.js
+++ b/plugins/queue/put.js
@@ -37,7 +37,7 @@ module.exports = () => ({
                         await scheduler.unzipArtifacts(executor, request.payload);
                         break;
                     case 'webhook':
-                        await scheduler.sendWebhook(executor, request.payload);
+                        await scheduler.queueWebhook(executor, request.payload);
                         break;
                     default:
                         await scheduler.start(executor, request.payload);

--- a/plugins/queue/put.js
+++ b/plugins/queue/put.js
@@ -36,6 +36,9 @@ module.exports = () => ({
                     case 'unzip':
                         await scheduler.unzipArtifacts(executor, request.payload);
                         break;
+                    case 'webhook':
+                        await scheduler.sendWebhook(executor, request.payload);
+                        break;
                     default:
                         await scheduler.start(executor, request.payload);
                         break;

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -720,7 +720,7 @@ async function unzipArtifacts(executor, config) {
  * Pushes webhooks to redis
  * @async  queueWebhook
  * @param  {Object} executor
- * @param  {Object} webhookConfig               webhookConfiguration
+ * @param  {Object} webhookConfig
  * @return {Promise}
  */
 async function queueWebhook(executor, webhookConfig) {

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -716,6 +716,19 @@ async function unzipArtifacts(executor, config) {
     return enq;
 }
 
+/**
+ * Pushes a message to unzip artifacts
+ * @async  sendWebhook
+ * @param  {Object} executor
+ * @param  {Object} webhookConfig               webhookConfiguration
+ * @return {Promise}
+ */
+async function sendWebhook(executor, webhookConfig) {
+    await executor.connect();
+
+    return executor.redisBreaker.runCommand('rpush', executor.webhookTable, JSON.stringify(webhookConfig));
+}
+
 module.exports = {
     init,
     start,
@@ -728,5 +741,6 @@ module.exports = {
     stopTimer,
     cleanUp,
     clearCache,
-    unzipArtifacts
+    unzipArtifacts,
+    sendWebhook
 };

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -723,10 +723,15 @@ async function unzipArtifacts(executor, config) {
  * @param  {Object} webhookConfig               webhookConfiguration
  * @return {Promise}
  */
-async function sendWebhook(executor, webhookConfig) {
+async function queueWebhook(executor, webhookConfig) {
     await executor.connect();
 
-    return executor.redisBreaker.runCommand('rpush', executor.webhookTable, JSON.stringify(webhookConfig));
+    return executor.queueBreaker.runCommand(
+        'enqueue',
+        executor.webhookQueue,
+        'sendWebhook',
+        JSON.stringify(webhookConfig)
+    );
 }
 
 module.exports = {
@@ -742,5 +747,5 @@ module.exports = {
     cleanUp,
     clearCache,
     unzipArtifacts,
-    sendWebhook
+    queueWebhook
 };

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -717,8 +717,8 @@ async function unzipArtifacts(executor, config) {
 }
 
 /**
- * Pushes a message to unzip artifacts
- * @async  sendWebhook
+ * Pushes webhooks to redis
+ * @async  queueWebhook
  * @param  {Object} executor
  * @param  {Object} webhookConfig               webhookConfiguration
  * @return {Promise}

--- a/test/lib/queue.test.js
+++ b/test/lib/queue.test.js
@@ -101,6 +101,7 @@ describe('queue test', () => {
             assert.strictEqual(executor.timeoutQueue, 'beta_timeoutConfigs');
             assert.strictEqual(executor.cacheQueue, 'beta_cache');
             assert.strictEqual(executor.unzipQueue, 'beta_unzip');
+            assert.strictEqual(executor.webhookTable, 'beta_webhooks');
         });
 
         it('throws when not given a redis connection', () => {

--- a/test/lib/queue.test.js
+++ b/test/lib/queue.test.js
@@ -101,7 +101,7 @@ describe('queue test', () => {
             assert.strictEqual(executor.timeoutQueue, 'beta_timeoutConfigs');
             assert.strictEqual(executor.cacheQueue, 'beta_cache');
             assert.strictEqual(executor.unzipQueue, 'beta_unzip');
-            assert.strictEqual(executor.webhookTable, 'beta_webhooks');
+            assert.strictEqual(executor.webhookQueue, 'beta_webhooks');
         });
 
         it('throws when not given a redis connection', () => {

--- a/test/plugins/queue/index.test.js
+++ b/test/plugins/queue/index.test.js
@@ -38,7 +38,8 @@ describe('queue plugin test', () => {
             stopFrozen: sinon.stub().resolves(),
             stopPeriodic: sinon.stub().resolves(),
             clearCache: sinon.stub().resolves(),
-            unzipArtifacts: sinon.stub().resolves()
+            unzipArtifacts: sinon.stub().resolves(),
+            queueWebhook: sinon.stub().resolves()
         };
 
         mockery.registerMock('./scheduler', schedulerMock);
@@ -263,6 +264,15 @@ describe('queue plugin test', () => {
 
             assert.equal(reply.statusCode, 200);
             assert.calledOnce(schedulerMock.unzipArtifacts);
+        });
+
+        it('returns 200 when pushing message to queue', async () => {
+            options.url = '/v1/queue/message?type=webhook';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.queueWebhook);
         });
     });
 });

--- a/test/plugins/queue/index.test.js
+++ b/test/plugins/queue/index.test.js
@@ -161,6 +161,15 @@ describe('queue plugin test', () => {
         });
 
         it('returns 200 when deleting message from queue', async () => {
+            options.url = '/v1/queue/message?type=frozen';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.stopFrozen);
+        });
+
+        it('returns 200 when deleting message from queue', async () => {
             options.url = '/v1/queue/message?type=timer';
 
             const reply = await server.inject(options);
@@ -211,7 +220,7 @@ describe('queue plugin test', () => {
             assert.equal(reply.statusCode, 403);
         });
 
-        it('returns 200 when deleting message from queue', async () => {
+        it('returns 200 when pushing message to queue', async () => {
             options.url = '/v1/queue/message?type=periodic';
 
             const reply = await server.inject(options);
@@ -220,16 +229,16 @@ describe('queue plugin test', () => {
             assert.calledOnce(schedulerMock.startPeriodic);
         });
 
-        it('returns 200 when deleting message from queue', async () => {
-            options.url = '/v1/queue/message?type=cache';
+        it('returns 200 when pushing message to queue', async () => {
+            options.url = '/v1/queue/message?type=frozen';
 
             const reply = await server.inject(options);
 
             assert.equal(reply.statusCode, 200);
-            assert.calledOnce(schedulerMock.clearCache);
+            assert.calledOnce(schedulerMock.startFrozen);
         });
 
-        it('returns 200 when deleting message from queue', async () => {
+        it('returns 200 when pushing message to queue', async () => {
             options.url = '/v1/queue/message?type=timer';
 
             const reply = await server.inject(options);
@@ -238,7 +247,16 @@ describe('queue plugin test', () => {
             assert.calledOnce(schedulerMock.startTimer);
         });
 
-        it('returns 200 when deleting message from queue', async () => {
+        it('returns 200 when pushing message to queue', async () => {
+            options.url = '/v1/queue/message?type=cache';
+
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 200);
+            assert.calledOnce(schedulerMock.clearCache);
+        });
+
+        it('returns 200 when pushing message to queue', async () => {
             options.url = '/v1/queue/message?type=unzip';
 
             const reply = await server.inject(options);

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -97,8 +97,7 @@ describe('scheduler test', () => {
             hdel: sinon.stub().yieldsAsync(),
             hset: sinon.stub().yieldsAsync(),
             set: sinon.stub().yieldsAsync(),
-            expire: sinon.stub().yieldsAsync(),
-            rpush: sinon.stub().yieldsAsync()
+            expire: sinon.stub().yieldsAsync()
         };
         redisConstructorMock = sinon.stub().returns(redisMock);
         cronMock = {
@@ -941,7 +940,7 @@ describe('scheduler test', () => {
         });
     });
 
-    describe('sendWebhook', () => {
+    describe('queueWebhook', () => {
         let webhookConfig;
 
         beforeEach(() => {
@@ -951,7 +950,7 @@ describe('scheduler test', () => {
         it("rejects if it can't establish a connection", function() {
             queueMock.connect.rejects(new Error("couldn't connect"));
 
-            return scheduler.sendWebhook(executor, webhookConfig).then(
+            return scheduler.queueWebhook(executor, webhookConfig).then(
                 () => {
                     assert.fail('Should not get here');
                 },
@@ -964,16 +963,16 @@ describe('scheduler test', () => {
         it("doesn't call connect if there's already a connection", () => {
             queueMock.connection.connected = true;
 
-            return scheduler.sendWebhook(executor, webhookConfig).then(() => {
+            return scheduler.queueWebhook(executor, webhookConfig).then(() => {
                 assert.notCalled(queueMock.connect);
             });
         });
 
         it('enqueues an webhook', () => {
-            return scheduler.sendWebhook(executor, webhookConfig).then(() => {
+            return scheduler.queueWebhook(executor, webhookConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
-                assert.calledOnce(redisMock.rpush);
-                assert.calledWith(redisMock.rpush, 'webhooks', JSON.stringify(webhookConfig));
+                assert.calledOnce(queueMock.enqueue);
+                assert.calledWith(queueMock.enqueue, 'webhooks', 'sendWebhook', JSON.stringify(webhookConfig));
             });
         });
     });


### PR DESCRIPTION
## Context
We are going to change the way we handle webhooks, and when the API receives a webhook, it will create a Queue Service event. Therefore, Queue Service needs to respond to the webhook-related requests from the API.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We implement `/queue/message?type=webhook` endpoint for webhook-related requests. Webhook configs sent here will be stored in redis. 
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1769#issuecomment-934107626
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
