### PR TITLE
fix(1769): add sendWebhooks

### DIFF
--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -218,11 +218,34 @@ async function updateBuild(updateConfig, retryStrategyFn) {
     );
 }
 
+/**
+ * Post the webhooks process
+ * @method processHooks
+ * @param {String} apiUri
+ * @param {String} token
+ * @param {String} webhookConfig as JSON format
+ * @param {Function} retryStrategyFn
+ * @return {Promise} response or error
+ */
+async function processHooks(apiUri, token, webhookConfig, retryStrategyFn) {
+    return request(formatOptions('POST', `${apiUri}/v4/processHooks`, token, webhookConfig, retryStrategyFn)).then(
+        res => {
+            logger.info(`POST /v4/processHooks completed, ${res.statusCode}, ${JSON.stringify(res.body)}`);
+            if ([200, 201, 204].includes(res.statusCode)) {
+                return res;
+            }
+
+            throw new Error(`Failed to process webhook with ${res.statusCode} code and ${res.body}`);
+        }
+    );
+}
+
 module.exports = {
     updateBuildStatus,
     updateStepStop,
     getCurrentStep,
     createBuildEvent,
     getPipelineAdmin,
-    updateBuild
+    updateBuild,
+    processHooks
 };

--- a/plugins/worker/worker.js
+++ b/plugins/worker/worker.js
@@ -42,7 +42,7 @@ async function shutDownAll(worker, scheduler) {
 const multiWorker = new NodeResque.MultiWorker(
     {
         connection: connectionDetails,
-        queues: [`${queuePrefix}builds`, `${queuePrefix}cache`],
+        queues: [`${queuePrefix}builds`, `${queuePrefix}cache`, `${queuePrefix}webhooks`],
         minTaskProcessors: workerConfig.minTaskProcessors,
         maxTaskProcessors: workerConfig.maxTaskProcessors,
         checkTimeout: workerConfig.checkTimeout,

--- a/test/plugins/worker/worker.test.js
+++ b/test/plugins/worker/worker.test.js
@@ -20,7 +20,7 @@ describe('Schedule test', () => {
     const job = { args: [{ buildId: 1 }] };
     const queue = 'testbuilds';
     const workerConfig = {
-        queues: ['mockQueuePrefix_builds', 'mockQueuePrefix_cache'],
+        queues: ['mockQueuePrefix_builds', 'mockQueuePrefix_cache', 'mockQueuePrefix_webhooks'],
         minTaskProcessors: 123,
         maxTaskProcessors: 234,
         checkTimeout: 345,


### PR DESCRIPTION
## Context
We modified it [last time](https://github.com/screwdriver-cd/queue-service/pull/38) to store a queue. I implement a worker that takes that queue and requests the API.

## Objective
Post what is received in the queue to the API

1. Receive json format string from queue.
    ```
    '{"foo": "bar"}'
    ```
2. Post the json received in the queue to the API with the bearer token.
    ```
    curl -X POST -H 'Authorization: Bearer dummy' -d '{"foo": "bar"}' ${apiUri}/v4/processHooks
    ```

## References
https://github.com/screwdriver-cd/screwdriver/issues/1769#issuecomment-934107626
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

The `/v4/processHooks` API that we will create later response should return only 200, 201, 204. If we need another status code when we implement the API, we can adjust it!
https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/index.js

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
