### PR TITLE
fix(1769): token is undefined when send webhook

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -58,20 +58,6 @@ module.exports = class ExecutorQueue {
                 this.redis[funcName](...args),
             breakerOptions
         );
-        this.requestRetryStrategy = response => {
-            if (Math.floor(response.statusCode / 100) !== 2) {
-                throw new Error('Retry limit reached');
-            }
-
-            return response;
-        };
-        this.requestRetryStrategyPostEvent = response => {
-            if (Math.floor(response.statusCode / 100) !== 2 && response.statusCode !== 404) {
-                throw new Error('Retry limit reached');
-            }
-
-            return response;
-        };
         this.fuseBox = new FuseBox();
         this.fuseBox.addFuse(this.queueBreaker);
         this.fuseBox.addFuse(this.redisBreaker);

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -8,6 +8,34 @@ const RETRY_LIMIT = 3;
 const RETRY_DELAY = 5;
 
 /**
+ * Callback function to retry when HTTP status code is not 2xx
+ * @param   {Object}    response
+ * @param   {Function}  retryWithMergedOptions
+ * @return  {Object}    response
+ */
+function requestRetryStrategy(response) {
+    if (Math.floor(response.statusCode / 100) !== 2) {
+        throw new Error('Retry limit reached');
+    }
+
+    return response;
+}
+
+/**
+ * Callback function to retry when HTTP status code is not 2xx and 404
+ * @param   {Object}    response
+ * @param   {Function}  retryWithMergedOptions
+ * @return  {Object}    response
+ */
+function requestRetryStrategyPostEvent(response) {
+    if (Math.floor(response.statusCode / 100) !== 2 && response.statusCode !== 404) {
+        throw new Error('Retry limit reached');
+    }
+
+    return response;
+}
+
+/**
  *
  * @param {String} method
  * @param {String} uri
@@ -241,6 +269,8 @@ async function processHooks(apiUri, token, webhookConfig, retryStrategyFn) {
 }
 
 module.exports = {
+    requestRetryStrategy,
+    requestRetryStrategyPostEvent,
     updateBuildStatus,
     updateStepStop,
     getCurrentStep,

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -730,7 +730,13 @@ async function queueWebhook(executor, webhookConfig) {
         'enqueue',
         executor.webhookQueue,
         'sendWebhook',
-        JSON.stringify(webhookConfig)
+        JSON.stringify({
+            webhookConfig,
+            token: executor.tokenGen({
+                service: 'queue',
+                scope: ['webhook_worker']
+            })
+        })
     );
 }
 

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -38,7 +38,7 @@ async function postBuildEvent(executor, eventConfig) {
             scope: ['user']
         });
 
-        const admin = await helper.getPipelineAdmin(token, apiUri, pipelineId, executor.requestRetryStrategy);
+        const admin = await helper.getPipelineAdmin(token, apiUri, pipelineId, helper.requestRetryStrategy);
 
         if (admin) {
             logger.info(
@@ -64,7 +64,7 @@ async function postBuildEvent(executor, eventConfig) {
                 buildEvent.buildId = buildId;
             }
 
-            await helper.createBuildEvent(apiUri, jwt, buildEvent, executor.requestRetryStrategyPostEvent);
+            await helper.createBuildEvent(apiUri, jwt, buildEvent, helper.requestRetryStrategyPostEvent);
         } else {
             logger.error(
                 `POST event for pipeline failed as no admin found: ${pipelineId}:${job.name}:${job.id}:${buildId}`
@@ -337,7 +337,7 @@ async function start(executor, config) {
                     apiUri,
                     payload
                 },
-                executor.requestRetryStrategy
+                helper.requestRetryStrategy
             )
             .catch(err => {
                 logger.error(`frozenBuilds: failed to update build status for build ${buildId}: ${err}`);
@@ -399,7 +399,7 @@ async function start(executor, config) {
                     apiUri,
                     payload: { stats: build.stats, status: 'QUEUED' }
                 },
-                executor.requestRetryStrategy
+                helper.requestRetryStrategy
             );
         }
     }

--- a/plugins/worker/lib/jobs.js
+++ b/plugins/worker/lib/jobs.js
@@ -278,18 +278,12 @@ async function clear(cacheConfig) {
  * Send message to processHooks API
  * @param {String} webhookConfig as String
  */
-async function sendWebhook(config) {
-    const parsedConfig = JSON.parse(config);
-    const { webhookConfig, token } = parsedConfig;
+async function sendWebhook(webhookConfig) {
+    const parsedConfig = JSON.parse(webhookConfig);
+    const { parsedWebhookConfig, token } = parsedConfig;
     const apiUri = ecosystem.api;
 
-    await helper.processHooks(apiUri, token, webhookConfig, request => {
-        if (Math.floor(response.statusCode / 100) !== 2 && response.statusCode !== 404) {
-            throw new Error('Retry limit reached');
-        }
-
-        return response;
-    });
+    await helper.processHooks(apiUri, token, parsedWebhookConfig, helper.requestRetryStrategyPostEvent);
 
     return null;
 }

--- a/plugins/worker/lib/jobs.js
+++ b/plugins/worker/lib/jobs.js
@@ -276,14 +276,14 @@ async function clear(cacheConfig) {
 
 /**
  * Send message to processHooks API
- * @param {String} webhookConfig as String
+ * @param {String} configs as String
  */
-async function sendWebhook(webhookConfig) {
-    const parsedConfig = JSON.parse(webhookConfig);
-    const { parsedWebhookConfig, token } = parsedConfig;
+async function sendWebhook(configs) {
+    const parsedConfig = JSON.parse(configs);
+    const { webhookConfig, token } = parsedConfig;
     const apiUri = ecosystem.api;
 
-    await helper.processHooks(apiUri, token, parsedWebhookConfig, helper.requestRetryStrategyPostEvent);
+    await helper.processHooks(apiUri, token, webhookConfig, helper.requestRetryStrategyPostEvent);
 
     return null;
 }

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -61,6 +61,47 @@ describe('Helper Test', () => {
         mockery.disable();
     });
 
+    it('return response when HTTP 200 status code for GET response', async () => {
+        const response = { statusCode: 200 };
+        const result = helper.requestRetryStrategy(response);
+
+        assert.strictEqual(result, response);
+    });
+
+    it('throw error when HTTP 404 status code for GET response', async () => {
+        const response = { statusCode: 404 };
+
+        try {
+            helper.requestRetryStrategy(response);
+        } catch (err) {
+            assert.strictEqual(err.message, 'Retry limit reached');
+        }
+    });
+
+    it('return response when HTTP 200 status code for POST response', async () => {
+        const response = { statusCode: 200 };
+        const result = helper.requestRetryStrategyPostEvent(response);
+
+        assert.strictEqual(result, response);
+    });
+
+    it('return response when HTTP 404 status code for POST response', async () => {
+        const response = { statusCode: 404 };
+        const result = helper.requestRetryStrategyPostEvent(response);
+
+        assert.strictEqual(result, response);
+    });
+
+    it('throw error when HTTP 500 status code for POST response', async () => {
+        const response = { statusCode: 500 };
+
+        try {
+            helper.requestRetryStrategyPostEvent(response);
+        } catch (err) {
+            assert.strictEqual(err.message, 'Retry limit reached');
+        }
+    });
+
     it('logs correct message when successfully update build failure status', async () => {
         mockRequest.resolves({ statusCode: 200 });
         try {

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -4,10 +4,10 @@
 
 const chai = require('chai');
 const util = require('util');
-const assert = chai.assert;
+const { assert } = chai;
 const mockery = require('mockery');
 const sinon = require('sinon');
-const EventEmitter = require('events').EventEmitter;
+const { EventEmitter } = require('events');
 const testConnection = require('../../data/testConnection.json');
 const testConfig = require('../../data/fullConfig.json');
 const testPipeline = require('../../data/testPipeline.json');
@@ -18,9 +18,7 @@ const partialTestConfig = {
     jobId,
     blockedBy
 };
-const partialTestConfigToString = Object.assign({}, partialTestConfig, {
-    blockedBy: blockedBy.toString()
-});
+const partialTestConfigToString = { ...partialTestConfig, blockedBy: blockedBy.toString() };
 const testAdmin = {
     username: 'admin'
 };
@@ -402,7 +400,7 @@ describe('scheduler test', () => {
             sandbox.useFakeTimers(dateNow);
             buildMock.stats = {};
             testConfig.build = buildMock;
-            const newConfig = Object.assign({}, testConfig);
+            const newConfig = { ...testConfig };
 
             delete newConfig.isPR;
 
@@ -496,7 +494,7 @@ describe('scheduler test', () => {
         it('enqueues a build and with enqueueTime', () => {
             buildMock.stats = {};
             testConfig.build = buildMock;
-            const config = Object.assign({}, testConfig, { enqueueTime: new Date() });
+            const config = { ...testConfig, enqueueTime: new Date() };
 
             return scheduler.start(executor, config).then(() => {
                 assert.calledTwice(queueMock.connect);
@@ -610,7 +608,7 @@ describe('scheduler test', () => {
 
         it('removes a start event from the queue and the cached buildconfig', () => {
             const deleteKey = `deleted_${jobId}_${buildId}`;
-            const stopConfig = Object.assign({ started: false }, partialTestConfigToString);
+            const stopConfig = { started: false, ...partialTestConfigToString };
 
             return scheduler.stop(executor, partialTestConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
@@ -623,7 +621,7 @@ describe('scheduler test', () => {
 
         it('adds a stop event to the queue if no start events were removed', () => {
             queueMock.del.resolves(0);
-            const stopConfig = Object.assign({ started: true }, partialTestConfigToString);
+            const stopConfig = { started: true, ...partialTestConfigToString };
 
             return scheduler.stop(executor, partialTestConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
@@ -634,10 +632,8 @@ describe('scheduler test', () => {
 
         it('adds a stop event to the queue if it has no blocked job', () => {
             queueMock.del.resolves(0);
-            const partialTestConfigUndefined = Object.assign({}, partialTestConfig, {
-                blockedBy: undefined
-            });
-            const stopConfig = Object.assign({ started: true }, partialTestConfigUndefined);
+            const partialTestConfigUndefined = { ...partialTestConfig, blockedBy: undefined };
+            const stopConfig = { started: true, ...partialTestConfigUndefined };
 
             return scheduler.stop(executor, partialTestConfigUndefined).then(() => {
                 assert.calledOnce(queueMock.connect);
@@ -650,14 +646,12 @@ describe('scheduler test', () => {
             queueMock.connection.connected = true;
 
             return scheduler
-                .stop(
-                    executor,
-                    Object.assign({}, partialTestConfig, {
-                        annotations: {
-                            'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
-                        }
-                    })
-                )
+                .stop(executor, {
+                    ...partialTestConfig,
+                    annotations: {
+                        'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
+                    }
+                })
                 .then(() => {
                     assert.notCalled(queueMock.connect);
                     assert.calledWith(queueMock.del, 'builds', 'start', [partialTestConfigToString]);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We modified it in [last PR](https://github.com/screwdriver-cd/queue-service/pull/39) to send a queued webhook to API. But its [token](https://github.com/screwdriver-cd/queue-service/pull/39/files#diff-86652e44de215913f4ec263e133b40855eafdc5cc5c1c773a4cd56918a424b63R284-R287) is `undefined`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Generate a token before store webhook in a queue, and store webhook and generated token in queue. (ref. [here](https://github.com/screwdriver-cd/queue-service/blob/master/plugins/queue/scheduler.js#L707))
- Move retry callbacks for API from [ExecutorQueue](https://github.com/screwdriver-cd/queue-service/blob/9e873c2a57ea1e8a007b6c9c1fc53f579c88e7c2/lib/queue.js#L61-L74) to [helper](https://github.com/screwdriver-cd/queue-service/blob/master/plugins/helper.js).
- Fix tests, eslint.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1769#issuecomment-934107626

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
