### PR TITLE
[2] fix(2666): Do not retry when processHooks times out

### DIFF
--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -269,8 +269,8 @@ async function processHooks(apiUri, token, webhookConfig) {
             calculateDelay,
             methods: ['POST']
         },
-        // Do not retry when request times out
-        errorCodes: ['ECONNRESET', 'EADDRINUSE', 'ECONNREFUSED', 'EPIPE', 'ENOTFOUND', 'ENETUNREACH', 'EAI_AGAIN']
+        // Do not retry if the request is received
+        errorCodes: ['EADDRINUSE', 'ECONNREFUSED', 'ENOTFOUND', 'ENETUNREACH', 'EAI_AGAIN']
     };
 
     return request(options)

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -6,6 +6,7 @@ const { queuePrefix } = require('../config/redis');
 
 const RETRY_LIMIT = 3;
 const RETRY_DELAY = 5;
+const calculateDelay = ({ computedValue }) => (computedValue ? RETRY_DELAY * 1000 : 0); // in ms
 
 /**
  * Callback function to retry when HTTP status code is not 2xx
@@ -58,7 +59,7 @@ function formatOptions(method, url, token, json, retryStrategyFn) {
     if (retryStrategyFn) {
         const retry = {
             limit: RETRY_LIMIT,
-            calculateDelay: ({ computedValue }) => (computedValue ? RETRY_DELAY * 1000 : 0) // in ms
+            calculateDelay
         };
 
         if (method === 'POST') {
@@ -265,7 +266,7 @@ async function processHooks(apiUri, token, webhookConfig) {
         json: webhookConfig,
         retry: {
             limit: RETRY_LIMIT,
-            calculateDelay: ({ computedValue }) => (computedValue ? RETRY_DELAY * 1000 : 0),
+            calculateDelay,
             methods: ['POST']
         },
         // Do not retry when request times out

--- a/plugins/worker/lib/jobs.js
+++ b/plugins/worker/lib/jobs.js
@@ -341,7 +341,7 @@ async function sendWebhook(configs) {
     const { webhookConfig, token } = parsedConfig;
     const apiUri = ecosystem.api;
 
-    await helper.processHooks(apiUri, token, webhookConfig, helper.requestRetryStrategyPostEvent);
+    await helper.processHooks(apiUri, token, webhookConfig);
 
     return null;
 }

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -547,7 +547,15 @@ describe('Helper Test', () => {
                 retry: {
                     limit: 3
                 },
-                hooks: { afterResponse: [retryFn] }
+                errorCodes: [
+                    'ECONNRESET',
+                    'EADDRINUSE',
+                    'ECONNREFUSED',
+                    'EPIPE',
+                    'ENOTFOUND',
+                    'ENETUNREACH',
+                    'EAI_AGAIN'
+                ]
             })
         );
     });
@@ -577,7 +585,15 @@ describe('Helper Test', () => {
                 retry: {
                     limit: 3
                 },
-                hooks: { afterResponse: [retryFn] }
+                errorCodes: [
+                    'ECONNRESET',
+                    'EADDRINUSE',
+                    'ECONNREFUSED',
+                    'EPIPE',
+                    'ENOTFOUND',
+                    'ENETUNREACH',
+                    'EAI_AGAIN'
+                ]
             })
         );
     });

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -544,7 +544,9 @@ describe('Helper Test', () => {
                 },
                 json: { foo: 123 },
                 retry: {
-                    limit: 3
+                    limit: 3,
+                    calculateDelay: sinon.match.func,
+                    methods: ['POST']
                 },
                 errorCodes: [
                     'ECONNRESET',

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -548,15 +548,7 @@ describe('Helper Test', () => {
                     calculateDelay: sinon.match.func,
                     methods: ['POST']
                 },
-                errorCodes: [
-                    'ECONNRESET',
-                    'EADDRINUSE',
-                    'ECONNREFUSED',
-                    'EPIPE',
-                    'ENOTFOUND',
-                    'ENETUNREACH',
-                    'EAI_AGAIN'
-                ]
+                errorCodes: ['EADDRINUSE', 'ECONNREFUSED', 'ENOTFOUND', 'ENETUNREACH', 'EAI_AGAIN']
             })
         );
     });
@@ -585,15 +577,7 @@ describe('Helper Test', () => {
                 retry: {
                     limit: 3
                 },
-                errorCodes: [
-                    'ECONNRESET',
-                    'EADDRINUSE',
-                    'ECONNREFUSED',
-                    'EPIPE',
-                    'ENOTFOUND',
-                    'ENETUNREACH',
-                    'EAI_AGAIN'
-                ]
+                errorCodes: ['EADDRINUSE', 'ECONNREFUSED', 'ENOTFOUND', 'ENETUNREACH', 'EAI_AGAIN']
             })
         );
     });
@@ -626,15 +610,7 @@ describe('Helper Test', () => {
                 retry: {
                     limit: 3
                 },
-                errorCodes: [
-                    'ECONNRESET',
-                    'EADDRINUSE',
-                    'ECONNREFUSED',
-                    'EPIPE',
-                    'ENOTFOUND',
-                    'ENETUNREACH',
-                    'EAI_AGAIN'
-                ]
+                errorCodes: ['EADDRINUSE', 'ECONNREFUSED', 'ENOTFOUND', 'ENETUNREACH', 'EAI_AGAIN']
             })
         );
     });

--- a/test/plugins/worker/lib/jobs.test.js
+++ b/test/plugins/worker/lib/jobs.test.js
@@ -753,13 +753,7 @@ describe('Jobs Unit Test', () => {
 
             return jobs.sendWebhook.perform(webhookConfig).then(result => {
                 assert.isNull(result);
-                assert.calledWith(
-                    helperMock.processHooks,
-                    'foo.api',
-                    'test_token',
-                    { foo: 123 },
-                    helperMock.requestRetryStrategyPostEvent
-                );
+                assert.calledWith(helperMock.processHooks, 'foo.api', 'test_token', { foo: 123 });
             });
         });
 


### PR DESCRIPTION
## Context
If the scm response is slow, API requests to `/v4/processHooks` may take a long time and time out. In that case, the request will be retry and the event will be created twice.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Fix so that it does not retry when there is a possibility request to `/v4/processHooks` is received. 
- Modify the response when access to `/v4/processHooks` times out.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2666
[got/retry](https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
