### PR TITLE
feat(1712): Relaxing blockedBy for same job

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node-resque": "^5.5.3",
     "redlock": "^4.2.0",
     "screwdriver-aws-producer-service": "^1.3.0",
-    "screwdriver-data-schema": "^21.30.0",
+    "screwdriver-data-schema": "^21.23.0",
     "screwdriver-executor-docker": "^5.0.2",
     "screwdriver-executor-jenkins": "^5.0.1",
     "screwdriver-executor-k8s": "^14.16.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node-resque": "^5.5.3",
     "redlock": "^4.2.0",
     "screwdriver-aws-producer-service": "^1.3.0",
-    "screwdriver-data-schema": "^21.17.0",
+    "screwdriver-data-schema": "^21.30.0",
     "screwdriver-executor-docker": "^5.0.2",
     "screwdriver-executor-jenkins": "^5.0.1",
     "screwdriver-executor-k8s": "^14.16.0",

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -5,6 +5,7 @@ const configSchema = require('screwdriver-data-schema').config;
 const TOKEN_CONFIG_SCHEMA = configSchema.tokenConfig;
 const { merge, reach } = require('@hapi/hoek');
 const Resque = require('node-resque');
+const hoek = require('@hapi/hoek');
 const cron = require('./utils/cron');
 const helper = require('../helper');
 const { timeOutOfWindows } = require('./utils/freezeWindows');
@@ -253,6 +254,8 @@ async function startPeriodic(executor, config) {
  */
 async function start(executor, config) {
     await executor.connect();
+    const allowSameJob = hoek.reach(config, 'allowSameJob', { default: false });
+    const blockTime = hoek.reach(config, 'blockTime', { default: 5 });
     const {
         build,
         buildId,
@@ -388,7 +391,9 @@ async function start(executor, config) {
             {
                 buildId,
                 jobId,
-                blockedBy: blockedBy.toString()
+                blockedBy: blockedBy.toString(),
+                allowSameJob,
+                blockTime
             }
         ]);
         if (buildStats) {

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -254,8 +254,7 @@ async function startPeriodic(executor, config) {
  */
 async function start(executor, config) {
     await executor.connect();
-    const allowSameJob = hoek.reach(config, 'allowSameJob', { default: false });
-    const blockTime = hoek.reach(config, 'blockTime', { default: 5 });
+
     const {
         build,
         buildId,
@@ -268,7 +267,9 @@ async function start(executor, config) {
         apiUri,
         pipeline,
         isPR,
-        prParentJobId
+        prParentJobId,
+        blockedBySameJob,
+        blockedBySameJobWaitTime
     } = config;
     const forceStart = /\[(force start)\]/.test(causeMessage);
 
@@ -392,8 +393,8 @@ async function start(executor, config) {
                 buildId,
                 jobId,
                 blockedBy: blockedBy.toString(),
-                allowSameJob,
-                blockTime
+                blockedBySameJob,
+                blockedBySameJobWaitTime
             }
         ]);
         if (buildStats) {

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -5,7 +5,6 @@ const configSchema = require('screwdriver-data-schema').config;
 const TOKEN_CONFIG_SCHEMA = configSchema.tokenConfig;
 const { merge, reach } = require('@hapi/hoek');
 const Resque = require('node-resque');
-const hoek = require('@hapi/hoek');
 const cron = require('./utils/cron');
 const helper = require('../helper');
 const { timeOutOfWindows } = require('./utils/freezeWindows');
@@ -15,6 +14,7 @@ const RETRY_DELAY = 5;
 const EXPIRE_TIME = 1800; // 30 mins
 const TEMPORAL_TOKEN_TIMEOUT = 12 * 60; // 12 hours in minutes
 const TEMPORAL_UNZIP_TOKEN_TIMEOUT = 2 * 60; // 2 hours in minutes
+const BLOCKED_BY_SAME_JOB_WAIT_TIME = 5;
 
 /**
  * Posts a new build event to the API
@@ -267,9 +267,7 @@ async function start(executor, config) {
         apiUri,
         pipeline,
         isPR,
-        prParentJobId,
-        blockedBySameJob,
-        blockedBySameJobWaitTime
+        prParentJobId
     } = config;
     const forceStart = /\[(force start)\]/.test(causeMessage);
 
@@ -386,6 +384,15 @@ async function start(executor, config) {
         Object.assign(config, { token });
         // Store the config in redis
         await executor.redisBreaker.runCommand('hset', executor.buildConfigTable, buildId, JSON.stringify(config));
+
+        const blockedBySameJob = reach(config, 'annotations>screwdriver.cd/blockedBySameJob', {
+            separator: '>',
+            default: true
+        });
+        const blockedBySameJobWaitTime = reach(config, 'annotations>screwdriver.cd/blockedBySameJobWaitTime', {
+            separator: '>',
+            default: BLOCKED_BY_SAME_JOB_WAIT_TIME
+        });
 
         // Note: arguments to enqueue are [queue name, job name, array of args]
         enq = await executor.queueBreaker.runCommand('enqueue', executor.buildQueue, 'start', [

--- a/plugins/worker/lib/BlockedBy.js
+++ b/plugins/worker/lib/BlockedBy.js
@@ -208,23 +208,23 @@ async function checkBlockingJob({ jobId, buildId }) {
 
     let blockedBy = this.args[0].blockedBy.split(',').map(jid => `${runningJobsPrefix}${jid}`);
 
-    const allowSameJob = this.args[0].allowSameJob;
-    const blockTime = this.args[0].blockTime;
+    const blockedBySameJob = this.args[0].blockedBySameJob;
+    const blockedBySameJobWaitTime = this.args[0].blockedBySameJobWaitTime;
     const json = await this.queueObject.connection.redis.hget(`${queuePrefix}timeoutConfigs`, lastRunningBuildId);
     const timeoutConfig = JSON.parse(json);
-    let notBlockedBySelf = false;
+    let notBlockedBySameJob = false;
 
-    if (allowSameJob && timeoutConfig) {
+    if (!blockedBySameJob && timeoutConfig) {
         const { startTime } = timeoutConfig;
         const diffMs = new Date().getTime() - new Date(startTime).getTime();
         const diffMins = Math.round(diffMs / 60000);
 
-        if (diffMins >= blockTime) {
-            notBlockedBySelf = true;
+        if (diffMins >= blockedBySameJobWaitTime) {
+            notBlockedBySameJob = true;
         }
     }
 
-    if (notBlockedBySelf || !enforceBlockedBySelf) {
+    if (notBlockedBySameJob || !enforceBlockedBySelf) {
         blockedBy = blockedBy.filter(key => key !== `${runningJobsPrefix}${jobId}`); // remove itself from blocking list
     }
 

--- a/plugins/worker/lib/BlockedBy.js
+++ b/plugins/worker/lib/BlockedBy.js
@@ -224,9 +224,7 @@ async function checkBlockingJob({ jobId, buildId }) {
     const timeoutConfig = JSON.parse(json);
     let notBlockedBySameJob = false;
 
-    if (!blockedBySameJob && !timeoutConfig) {
-        notBlockedBySameJob = true;
-    } else if (!blockedBySameJob && timeoutConfig) {
+    if (!blockedBySameJob && timeoutConfig) {
         const { startTime } = timeoutConfig;
         const diffMs = new Date().getTime() - new Date(startTime).getTime();
         const diffMins = Math.round(diffMs / 60000);

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -12,13 +12,26 @@ const testConnection = require('../../data/testConnection.json');
 const testConfig = require('../../data/fullConfig.json');
 const testPipeline = require('../../data/testPipeline.json');
 const testJob = require('../../data/testJob.json');
-const { buildId, jobId, blockedBy } = testConfig;
+const { buildId, jobId, blockedBy, allowSameJob, blockTime } = testConfig;
 const partialTestConfig = {
     buildId,
     jobId,
-    blockedBy
+    blockedBy,
+    allowSameJob,
+    blockTime
 };
-const partialTestConfigToString = { ...partialTestConfig, blockedBy: blockedBy.toString() };
+const partialTestDefaultConfig = {
+    buildId,
+    jobId,
+    blockedBy: blockedBy.toString(),
+    allowSameJob: false,
+    blockTime: 5
+};
+const partialTestStopConfigToString = {
+    buildId,
+    jobId,
+    blockedBy: blockedBy.toString()
+};
 const testAdmin = {
     username: 'admin'
 };
@@ -374,7 +387,7 @@ describe('scheduler test', () => {
             return scheduler.start(executor, testConfig).then(() => {
                 assert.calledTwice(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId, JSON.stringify(testConfig));
-                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestDefaultConfig]);
                 assert.calledTwice(executor.tokenGen);
                 assert.calledWith(
                     helperMock.updateBuild,
@@ -446,7 +459,7 @@ describe('scheduler test', () => {
             return scheduler.start(executor, testConfig).then(() => {
                 assert.calledTwice(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId, JSON.stringify(testConfig));
-                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestDefaultConfig]);
                 assert.calledTwice(executor.tokenGen);
                 assert.calledWith(executor.tokenGen, {
                     buildId: testConfig.buildId,
@@ -499,7 +512,7 @@ describe('scheduler test', () => {
             return scheduler.start(executor, config).then(() => {
                 assert.calledTwice(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId, JSON.stringify(config));
-                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestDefaultConfig]);
             });
         });
 
@@ -507,7 +520,7 @@ describe('scheduler test', () => {
             scheduler.start(executor, testConfig).then(() => {
                 assert.calledTwice(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId, JSON.stringify(testConfig));
-                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestDefaultConfig]);
             }));
 
         it("doesn't call connect if there's already a connection", () => {
@@ -515,7 +528,7 @@ describe('scheduler test', () => {
 
             return scheduler.start(executor, testConfig).then(() => {
                 assert.notCalled(queueMock.connect);
-                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestDefaultConfig]);
             });
         });
     });
@@ -608,11 +621,11 @@ describe('scheduler test', () => {
 
         it('removes a start event from the queue and the cached buildconfig', () => {
             const deleteKey = `deleted_${jobId}_${buildId}`;
-            const stopConfig = { started: false, ...partialTestConfigToString };
+            const stopConfig = { started: false, ...partialTestStopConfigToString };
 
             return scheduler.stop(executor, partialTestConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
-                assert.calledWith(queueMock.del, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledWith(queueMock.del, 'builds', 'start', [partialTestStopConfigToString]);
                 assert.calledWith(redisMock.set, deleteKey, '');
                 assert.calledWith(redisMock.expire, deleteKey, 1800);
                 assert.calledWith(queueMock.enqueue, 'builds', 'stop', [stopConfig]);
@@ -621,18 +634,18 @@ describe('scheduler test', () => {
 
         it('adds a stop event to the queue if no start events were removed', () => {
             queueMock.del.resolves(0);
-            const stopConfig = { started: true, ...partialTestConfigToString };
+            const stopConfig = { started: true, ...partialTestStopConfigToString };
 
             return scheduler.stop(executor, partialTestConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
-                assert.calledWith(queueMock.del, 'builds', 'start', [partialTestConfigToString]);
+                assert.calledWith(queueMock.del, 'builds', 'start', [partialTestStopConfigToString]);
                 assert.calledWith(queueMock.enqueue, 'builds', 'stop', [stopConfig]);
             });
         });
 
         it('adds a stop event to the queue if it has no blocked job', () => {
             queueMock.del.resolves(0);
-            const partialTestConfigUndefined = { ...partialTestConfig, blockedBy: undefined };
+            const partialTestConfigUndefined = { ...partialTestStopConfigToString, blockedBy: undefined };
             const stopConfig = { started: true, ...partialTestConfigUndefined };
 
             return scheduler.stop(executor, partialTestConfigUndefined).then(() => {
@@ -654,7 +667,7 @@ describe('scheduler test', () => {
                 })
                 .then(() => {
                     assert.notCalled(queueMock.connect);
-                    assert.calledWith(queueMock.del, 'builds', 'start', [partialTestConfigToString]);
+                    assert.calledWith(queueMock.del, 'builds', 'start', [partialTestStopConfigToString]);
                 });
         });
     });

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -12,7 +12,9 @@ const testConnection = require('../../data/testConnection.json');
 const testConfig = require('../../data/fullConfig.json');
 const testPipeline = require('../../data/testPipeline.json');
 const testJob = require('../../data/testJob.json');
-const { buildId, jobId, blockedBy, blockedBySameJob, blockedBySameJobWaitTime } = testConfig;
+const { buildId, jobId, blockedBy } = testConfig;
+const blockedBySameJob = true;
+const blockedBySameJobWaitTime = 5;
 const partialTestConfig = {
     buildId,
     jobId,
@@ -24,8 +26,8 @@ const partialTestDefaultConfig = {
     buildId,
     jobId,
     blockedBy: blockedBy.toString(),
-    blockedBySameJob: true,
-    blockedBySameJobWaitTime: 5
+    blockedBySameJob,
+    blockedBySameJobWaitTime
 };
 const partialTestStopConfigToString = {
     buildId,

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -12,20 +12,20 @@ const testConnection = require('../../data/testConnection.json');
 const testConfig = require('../../data/fullConfig.json');
 const testPipeline = require('../../data/testPipeline.json');
 const testJob = require('../../data/testJob.json');
-const { buildId, jobId, blockedBy, allowSameJob, blockTime } = testConfig;
+const { buildId, jobId, blockedBy, blockedBySameJob, blockedBySameJobWaitTime } = testConfig;
 const partialTestConfig = {
     buildId,
     jobId,
     blockedBy,
-    allowSameJob,
-    blockTime
+    blockedBySameJob,
+    blockedBySameJobWaitTime
 };
 const partialTestDefaultConfig = {
     buildId,
     jobId,
     blockedBy: blockedBy.toString(),
-    allowSameJob: false,
-    blockTime: 5
+    blockedBySameJob: true,
+    blockedBySameJobWaitTime: 5
 };
 const partialTestStopConfigToString = {
     buildId,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
allowing user to override blocking behavior of builds from same job
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
when specified, build from same job will no longer block each other with a default wait time of 5 minute.
builds will trigger sequentially base on wait time and order of waiting queue
## References
https://github.com/screwdriver-cd/screwdriver/issues/1712
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
