### PR TITLE
fix: region map value name

### DIFF
--- a/plugins/worker/lib/jobs.js
+++ b/plugins/worker/lib/jobs.js
@@ -62,7 +62,7 @@ const blockedByOptions = {
 const AWS_REGION_MAP = {
     north: 'n',
     west: 'w',
-    northeast: 'nw',
+    northeast: 'ne',
     east: 'e',
     south: 's',
     central: 'c',


### PR DESCRIPTION
## Context

The short-name value in the AWS region map was incorrect as per the region names

## Objective

This PR fixes the value for key `northeast`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
