### PR TITLE
[JSFIX] Major version upgrade of uuid from version N/A to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "screwdriver-logger": "^1.0.2",
     "screwdriver-request": "^1.0.2",
     "string-hash": "^1.1.3",
-    "uuid": "^7.0.2"
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "chai": "^4.3.4",


### PR DESCRIPTION
This pull request was created by [mR4smussen](https://github.com/mR4smussen) using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It upgrades uuid to version 8.0.0.

The JSFIX tool used advanced program analysis to determine how uuid is used by screwdriver-queue-service and how it is affected by breaking changes in uuid version 8.0.0 (see details below). JSFIX checked for the 2 breaking changes affecting uuid version 8.0.0 and found 0 occurrences in screwdriver-queue-service. 

<strong>Install the [JSFIX GitHub app](https://github.com/apps/jsfix-updater) to receive other package updates from JSFIX.</strong>

***

<h3>Breaking change details</h3>

<details>
<summary><strong> 🚧 - Files JSFIX failed to analyze (carefully check that no source files are in this list before merging)</strong></summary>

* Dockerfile (TypeError) - emessage: Cannot read properties of null (reading 'startsWith').

</details>

<details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* For native ECMAScript Module (ESM) usage in Node.js only named exports are exposed, there is no more default export.
* Deep requiring specific algorithms of this library like require('uuid/v4'), which has been deprecated in uuid@7, is no longer supported.
</details>



***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.