### PR TITLE
fix: Remove laabr

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "joi": "^17.5.0",
     "js-yaml": "^3.14.1",
     "jsonwebtoken": "^8.5.1",
-    "laabr": "^6.1.3",
     "node-resque": "^5.5.3",
     "redlock": "^4.2.0",
     "screwdriver-aws-producer-service": "^1.3.0",


### PR DESCRIPTION
## Context
`Laabr` contains vulnerable `lodash` and is detected by security tools. However, it is not used anywhere.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We remove `laabr` from `package.json`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://security.snyk.io/vuln/SNYK-JS-LODASHSET-1320032
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
