### PR TITLE
fix(2743): get job and pipeline data from API just before start periodic build

### DIFF
--- a/config/redis.js
+++ b/config/redis.js
@@ -3,7 +3,7 @@
 const config = require('config');
 
 const queueConfig = config.get('queue');
-const connectionType = queueConfig.connectionType;
+const { connectionType } = queueConfig;
 
 if (!connectionType || (connectionType !== 'redis' && connectionType !== 'redisCluster')) {
     throw new Error(

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -30,7 +30,6 @@ module.exports = class ExecutorQueue {
         this.periodicBuildQueue = `${this.prefix}periodicBuilds`;
         this.frozenBuildQueue = `${this.prefix}frozenBuilds`;
         this.buildConfigTable = `${this.prefix}buildConfigs`;
-        this.periodicBuildTable = `${this.prefix}periodicBuildConfigs`;
         this.frozenBuildTable = `${this.prefix}frozenBuildConfigs`;
         this.tokenGen = null;
         this.userTokenGen = null;

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -248,6 +248,50 @@ async function updateBuild(updateConfig, retryStrategyFn) {
 }
 
 /**
+ * Get job config
+ * @param {Object} config
+ * @param {Number} config.jobId
+ * @param {String} config.token
+ * @param {String} config.apiUri
+ * @param {Object} retryStrategyFn
+ */
+async function getJobConfig(config, retryStrategyFn) {
+    const { jobId, token, apiUri } = config;
+
+    return request(formatOptions('GET', `${apiUri}/v4/jobs/${jobId}`, token, undefined, retryStrategyFn)).then(res => {
+        logger.info(`GET /v4/jobs/${jobId} completed with attempts, ${res.statusCode}, ${res.attempts}`);
+        if (res.statusCode === 200) {
+            return res.body;
+        }
+
+        throw new Error(`Failed to get job config with ${res.statusCode} code and ${JSON.stringify(res.body)}`);
+    });
+}
+
+/**
+ * Get pipeline config
+ * @param {Object} config
+ * @param {Number} config.pipelineId
+ * @param {String} config.token
+ * @param {String} config.apiUri
+ * @param {Object} retryStrategyFn
+ */
+async function getPipelineConfig(config, retryStrategyFn) {
+    const { pipelineId, token, apiUri } = config;
+
+    return request(
+        formatOptions('GET', `${apiUri}/v4/pipelines/${pipelineId}`, token, undefined, retryStrategyFn)
+    ).then(res => {
+        logger.info(`GET /v4/pipelines/${pipelineId} completed with attempts, ${res.statusCode}, ${res.attempts}`);
+        if (res.statusCode === 200) {
+            return res.body;
+        }
+
+        throw new Error(`Failed to get pipeline config with ${res.statusCode} code and ${JSON.stringify(res.body)}`);
+    });
+}
+
+/**
  * Notify user with job status
  * @param {Number} jobId
  * @param {String} token
@@ -328,6 +372,8 @@ module.exports = {
     getCurrentStep,
     createBuildEvent,
     getPipelineAdmin,
+    getJobConfig,
+    getPipelineConfig,
     updateBuild,
     notifyJob,
     processHooks

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -169,7 +169,7 @@ async function getCurrentStep(stepConfig) {
             return null;
         }
 
-        logger.error(`PUT /v4/builds/${buildId}/steps?status=active returned non 200, ${res.statusCode}, ${res.body}`);
+        logger.error(`GET /v4/builds/${buildId}/steps?status=active returned non 200, ${res.statusCode}, ${res.body}`);
 
         throw new Error(`Failed to getCurrentStep with ${res.statusCode} code and ${res.body}`);
     });
@@ -214,7 +214,7 @@ async function getPipelineAdmin(token, apiUri, pipelineId, retryStrategyFn) {
         formatOptions('GET', `${apiUri}/v4/pipelines/${pipelineId}/admin`, token, undefined, retryStrategyFn)
     ).then(res => {
         logger.info(
-            `POST /v4/pipelines/${pipelineId}/admin completed with attempts, ${res.statusCode}, ${res.attempts}`
+            `GET /v4/pipelines/${pipelineId}/admin completed with attempts, ${res.statusCode}, ${res.attempts}`
         );
         if (res.statusCode === 200) {
             return res.body;

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Config = require('config');
 const logger = require('screwdriver-logger');
 const configSchema = require('screwdriver-data-schema').config;
 const TOKEN_CONFIG_SCHEMA = configSchema.tokenConfig;
@@ -9,6 +10,7 @@ const cron = require('./utils/cron');
 const helper = require('../helper');
 const { timeOutOfWindows } = require('./utils/freezeWindows');
 const { queueNamespace } = require('../../config/redis');
+const ecosystem = Config.get('ecosystem');
 const DEFAULT_BUILD_TIMEOUT = 90;
 const RETRY_LIMIT = 3;
 const RETRY_DELAY = 5;
@@ -109,11 +111,9 @@ async function postBuildEvent(executor, eventConfig) {
 async function stopPeriodic(executor, config) {
     await executor.connect();
 
-    await executor.queueBreaker.runCommand('delDelayed', executor.periodicBuildQueue, 'startDelayed', [
+    return executor.queueBreaker.runCommand('delDelayed', executor.periodicBuildQueue, 'startDelayed', [
         { jobId: config.jobId }
     ]);
-
-    return executor.redisBreaker.runCommand('hdel', executor.periodicBuildTable, config.jobId);
 }
 
 /**
@@ -192,23 +192,6 @@ async function startPeriodic(executor, config) {
         await executor.connect();
 
         const next = cron.next(cron.transform(buildCron, job.id));
-
-        try {
-            // Store the config in redis
-            await executor.redisBreaker.runCommand(
-                'hset',
-                executor.periodicBuildTable,
-                job.id,
-                JSON.stringify(
-                    Object.assign(config, {
-                        isUpdate: false,
-                        triggerBuild: false
-                    })
-                )
-            );
-        } catch (err) {
-            logger.error(`failed to store the config in Redis for job ${job.id}: ${err}`);
-        }
 
         // Note: arguments to enqueueAt are [timestamp, queue name, job name, array of args]
         let shouldRetry = false;
@@ -469,22 +452,46 @@ async function init(executor) {
     // Jobs object to register the worker with
     const jobs = {
         startDelayed: {
-            perform: async jobConfig => {
+            perform: async config => {
                 try {
-                    logger.info(`Started processing periodic job ${jobConfig.jobId}`);
+                    const apiUri = ecosystem.api;
+                    const { jobId } = config;
 
-                    const fullConfig = await executor.redisBreaker.runCommand(
-                        'hget',
-                        executor.periodicBuildTable,
-                        jobConfig.jobId
-                    );
+                    logger.info(`Started processing periodic job ${jobId}`);
 
-                    return await startPeriodic(
-                        executor,
-                        Object.assign(JSON.parse(fullConfig), {
-                            triggerBuild: true
-                        })
-                    );
+                    const buildToken = executor.tokenGen({
+                        jobId,
+                        service: 'queue',
+                        scope: ['build']
+                    });
+
+                    const job = await helper.getJobConfig({
+                        jobId,
+                        token: buildToken,
+                        apiUri
+                    });
+
+                    const pipelineToken = executor.tokenGen({
+                        pipelineId: job.pipelineId,
+                        service: 'queue',
+                        scope: ['pipeline']
+                    });
+
+                    const pipeline = await helper.getPipelineConfig({
+                        pipelineId: job.pipelineId,
+                        token: pipelineToken,
+                        apiUri
+                    });
+
+                    const fullConfig = {
+                        pipeline,
+                        job,
+                        apiUri,
+                        isUpdate: false,
+                        triggerBuild: true
+                    };
+
+                    return await startPeriodic(executor, fullConfig);
                 } catch (err) {
                     logger.error(`err in startDelayed job: ${err}`);
                     throw err;

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -22,11 +22,11 @@ const BLOCKED_BY_SAME_JOB_WAIT_TIME = 5;
 /**
  * Posts a new build event to the API
  * @method postBuildEvent
- * @param {Object} config           Configuration
- * @param {Number} [config.eventId] Optional Parent event ID (optional)
- * @param {Object} config.pipeline  Pipeline of the job
- * @param {Object} config.job       Job object to create periodic builds for
- * @param {String} config.apiUri    Base URL of the Screwdriver API
+ * @param {Object} eventConfig           Configuration
+ * @param {Number} [eventConfig.eventId] Optional Parent event ID (optional)
+ * @param {Object} eventConfig.pipeline  Pipeline of the job
+ * @param {Object} eventConfig.job       Job object to create periodic builds for
+ * @param {String} eventConfig.apiUri    Base URL of the Screwdriver API
  * @return {Promise}
  */
 async function postBuildEvent(executor, eventConfig) {

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -221,7 +221,7 @@ async function startPeriodic(executor, config) {
     }
     logger.info(`added to delayed queue for job ${job.id}`);
 
-    if (triggerBuild) {
+    if (triggerBuild && !job.archived) {
         try {
             await postBuildEvent(executor, config);
         } catch (err) {

--- a/test/plugins/helper.test.js
+++ b/test/plugins/helper.test.js
@@ -525,6 +525,190 @@ describe('Helper Test', () => {
         );
     });
 
+    it('Gets the job config correctly', async () => {
+        mockRequest.resolves({
+            statusCode: 200,
+            body: { id: 123 }
+        });
+        const retryFn = sinon.stub();
+        const jobId = 123;
+        let result;
+
+        try {
+            result = await helper.getJobConfig({ jobId, token: 'fake', apiUri: 'foo.bar' }, retryFn);
+        } catch (err) {
+            assert.isNull(err);
+        }
+
+        assert.calledWith(
+            mockRequest,
+            sinon.match({
+                method: 'GET',
+                url: `foo.bar/v4/jobs/${jobId}`,
+                headers: {
+                    Authorization: 'Bearer fake'
+                },
+                retry: {
+                    limit: 3
+                },
+                hooks: { afterResponse: [retryFn] }
+            })
+        );
+        assert.equal(result.id, '123');
+    });
+
+    it('throws when cannot get job config correctly', async () => {
+        mockRequest.resolves({
+            statusCode: 403,
+            body: { id: 123 }
+        });
+        const retryFn = sinon.stub();
+        const jobId = 123;
+
+        try {
+            await helper.getJobConfig({ jobId, token: 'fake', apiUri: 'foo.bar' }, retryFn);
+        } catch (err) {
+            assert.strictEqual(err.message, 'Failed to get job config with 403 code and {"id":123}');
+        }
+
+        assert.calledWith(
+            mockRequest,
+            sinon.match({
+                method: 'GET',
+                url: `foo.bar/v4/jobs/${jobId}`,
+                headers: {
+                    Authorization: 'Bearer fake'
+                },
+                retry: {
+                    limit: 3
+                },
+                hooks: { afterResponse: [retryFn] }
+            })
+        );
+    });
+
+    it('throws when get error fetching job config', async () => {
+        const requestErr = new Error('invalid');
+
+        mockRequest.rejects(requestErr);
+
+        const retryFn = sinon.stub();
+        const jobId = 123;
+
+        try {
+            await helper.getJobConfig({ jobId, token: 'fake', apiUri: 'foo.bar' }, retryFn);
+        } catch (err) {
+            assert.strictEqual(err.message, requestErr.message);
+        }
+
+        assert.calledWith(
+            mockRequest,
+            sinon.match({
+                method: 'GET',
+                url: `foo.bar/v4/jobs/${jobId}`,
+                headers: {
+                    Authorization: 'Bearer fake'
+                },
+                retry: {
+                    limit: 3
+                },
+                hooks: { afterResponse: [retryFn] }
+            })
+        );
+    });
+
+    it('Gets the pipeline config correctly', async () => {
+        mockRequest.resolves({
+            statusCode: 200,
+            body: { id: 123 }
+        });
+        const retryFn = sinon.stub();
+        const pipelineId = 123;
+        let result;
+
+        try {
+            result = await helper.getPipelineConfig({ pipelineId, token: 'fake', apiUri: 'foo.bar' }, retryFn);
+        } catch (err) {
+            assert.isNull(err);
+        }
+
+        assert.calledWith(
+            mockRequest,
+            sinon.match({
+                method: 'GET',
+                url: `foo.bar/v4/pipelines/${pipelineId}`,
+                headers: {
+                    Authorization: 'Bearer fake'
+                },
+                retry: {
+                    limit: 3
+                },
+                hooks: { afterResponse: [retryFn] }
+            })
+        );
+        assert.equal(result.id, '123');
+    });
+
+    it('throws when cannot get pipeline config correctly', async () => {
+        mockRequest.resolves({
+            statusCode: 403,
+            body: { id: 123 }
+        });
+        const retryFn = sinon.stub();
+        const pipelineId = 123;
+
+        try {
+            await helper.getPipelineConfig({ pipelineId, token: 'fake', apiUri: 'foo.bar' }, retryFn);
+        } catch (err) {
+            assert.strictEqual(err.message, 'Failed to get pipeline config with 403 code and {"id":123}');
+        }
+
+        assert.calledWith(
+            mockRequest,
+            sinon.match({
+                method: 'GET',
+                url: `foo.bar/v4/pipelines/${pipelineId}`,
+                headers: {
+                    Authorization: 'Bearer fake'
+                },
+                retry: {
+                    limit: 3
+                },
+                hooks: { afterResponse: [retryFn] }
+            })
+        );
+    });
+
+    it('throws when get error fetching pipeline config', async () => {
+        const requestErr = new Error('invalid');
+
+        mockRequest.rejects(requestErr);
+
+        const retryFn = sinon.stub();
+        const pipelineId = 123;
+
+        try {
+            await helper.getPipelineConfig({ pipelineId, token: 'fake', apiUri: 'foo.bar' }, retryFn);
+        } catch (err) {
+            assert.strictEqual(err.message, requestErr.message);
+        }
+
+        assert.calledWith(
+            mockRequest,
+            sinon.match({
+                method: 'GET',
+                url: `foo.bar/v4/pipelines/${pipelineId}`,
+                headers: {
+                    Authorization: 'Bearer fake'
+                },
+                retry: {
+                    limit: 3
+                },
+                hooks: { afterResponse: [retryFn] }
+            })
+        );
+    });
+
     it('Post a webhooks process with retry', async () => {
         mockRequest.resolves({ statusCode: 200 });
 

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -244,12 +244,6 @@ describe('scheduler test', () => {
         it('enqueues a new delayed job in the queue', () =>
             scheduler.startPeriodic(executor, testDelayedConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
-                assert.calledWith(
-                    redisMock.hset,
-                    'periodicBuildConfigs',
-                    testJob.id,
-                    JSON.stringify(testDelayedConfig)
-                );
                 assert.calledWith(cronMock.transform, '* * * * *', testJob.id);
                 assert.calledWith(cronMock.next, 'H H H H H');
                 assert.calledWith(queueMock.enqueueAt, 1500000, 'periodicBuilds', 'startDelayed', [
@@ -275,12 +269,6 @@ describe('scheduler test', () => {
 
             return scheduler.startPeriodic(executor, testDelayedConfig).then(() => {
                 assert.calledTwice(queueMock.connect);
-                assert.calledWith(
-                    redisMock.hset,
-                    'periodicBuildConfigs',
-                    testJob.id,
-                    JSON.stringify(testDelayedConfig)
-                );
                 assert.calledWith(queueMock.enqueueAt, 1500000, 'periodicBuilds', 'startDelayed', [
                     {
                         jobId: testJob.id
@@ -291,7 +279,6 @@ describe('scheduler test', () => {
                         jobId: testJob.id
                     }
                 ]);
-                assert.calledWith(redisMock.hdel, 'periodicBuildConfigs', testJob.id);
             });
         });
 
@@ -309,7 +296,6 @@ describe('scheduler test', () => {
                         jobId: testJob.id
                     }
                 ]);
-                assert.calledWith(redisMock.hdel, 'periodicBuildConfigs', testJob.id);
             });
         });
 
@@ -327,7 +313,6 @@ describe('scheduler test', () => {
                         jobId: testJob.id
                     }
                 ]);
-                assert.calledWith(redisMock.hdel, 'periodicBuildConfigs', testJob.id);
             });
         });
 
@@ -358,7 +343,6 @@ describe('scheduler test', () => {
                         jobId: testJob.id
                     }
                 ]);
-                assert.calledWith(redisMock.hdel, 'periodicBuildConfigs', testJob.id);
                 assert.calledOnce(executor.tokenGen);
                 assert.calledOnce(helperMock.getPipelineAdmin);
                 assert.calledOnce(executor.userTokenGen);
@@ -390,12 +374,6 @@ describe('scheduler test', () => {
                 assert.calledOnce(helperMock.getPipelineAdmin);
                 assert.calledWith(helperMock.createBuildEvent, ...options);
                 assert.calledOnce(queueMock.connect);
-                assert.calledWith(
-                    redisMock.hset,
-                    'periodicBuildConfigs',
-                    testJob.id,
-                    JSON.stringify(testDelayedConfig)
-                );
                 assert.calledWith(cronMock.transform, '* * * * *', testJob.id);
                 assert.calledWith(cronMock.next, 'H H H H H');
                 assert.calledWith(queueMock.enqueueAt, 1500000, 'periodicBuilds', 'startDelayed', [

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -365,18 +365,6 @@ describe('scheduler test', () => {
             testDelayedConfig.job.archived = true;
             testDelayedConfig.triggerBuild = true;
 
-            const options = [
-                'http://localhost',
-                'admintoken',
-                {
-                    causeMessage: 'Started by periodic build scheduler',
-                    creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
-                    pipelineId: testDelayedConfig.pipeline.id,
-                    startFrom: testDelayedConfig.job.name
-                },
-                helperMock.requestRetryStrategyPostEvent
-            ];
-
             return scheduler.startPeriodic(executor, testDelayedConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
                 assert.notCalled(redisMock.hset);

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -386,10 +386,7 @@ describe('scheduler test', () => {
                         jobId: testJob.id
                     }
                 ]);
-                assert.calledOnce(executor.tokenGen);
-                assert.calledOnce(helperMock.getPipelineAdmin);
-                assert.calledOnce(executor.userTokenGen);
-                assert.calledWith(helperMock.createBuildEvent, ...options);
+                assert.notCalled(helperMock.createBuildEvent);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When a job is archived in API, the the job data in redis (`periodicBuildConfigs`) is also synchronized.
But synchronization may fail due to communication errors with redis.
Then the deleted (archived) job will continue to run periodically and create events which is `No jobs to start`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR changes `queue-service` to get job and pipeline data from API just before start periodic build.
Thus `periodicBuildConfigs` table will be no longer needed, we can remove this table.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issues
- https://github.com/screwdriver-cd/screwdriver/issues/2743

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
