### PR TITLE
fix: queue-service can't start when WORKER_MAX_TASK_PROCESSORS is set

### DIFF
--- a/plugins/worker/worker.js
+++ b/plugins/worker/worker.js
@@ -43,10 +43,10 @@ const multiWorker = new MultiWorker(
     {
         connection: resqueConnection,
         queues: [`${queuePrefix}builds`, `${queuePrefix}cache`, `${queuePrefix}webhooks`],
-        minTaskProcessors: workerConfig.minTaskProcessors,
-        maxTaskProcessors: workerConfig.maxTaskProcessors,
-        checkTimeout: workerConfig.checkTimeout,
-        maxEventLoopDelay: workerConfig.maxEventLoopDelay
+        minTaskProcessors: parseInt(workerConfig.minTaskProcessors, 10),
+        maxTaskProcessors: parseInt(workerConfig.maxTaskProcessors, 10),
+        checkTimeout: parseInt(workerConfig.checkTimeout, 10),
+        maxEventLoopDelay: parseInt(workerConfig.maxEventLoopDelay, 10)
     },
     jobs
 );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
queue-service fails to start when using [WORKER_MAX_TASK_PROCESSORS](https://github.com/screwdriver-cd/queue-service/blob/2a6d06aefa3cef9f4c16457c79024bb64e28a084/config/custom-environment-variables.yaml#L257).

```
{"level":"error","message":"Unhandled error: RangeError [ERR_OUT_OF_RANGE]: The value of \"n\" is out of range. It must be a non-negative number. Received '1050'\n    at EventEmitter.setMaxListeners (events.js:200:11)\n    at new MultiWorker (/usr/src/app/node_modules/node-resque/dist/core/multiWorker.js:20:38)\n    at Object.<anonymous> (/usr/src/app/node_modules/screwdriver-queue-service/plugins/worker/worker.js:42:21)\n    at Module._compile (internal/modules/cjs/loader.js:999:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)\n    at Module.load (internal/modules/cjs/loader.js:863:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:708:14)\n    at Module.require (internal/modules/cjs/loader.js:887:19)\n    at require (internal/modules/cjs/helpers.js:74:18)\n    at Object.<anonymous> (/usr/src/app/node_modules/screwdriver-queue-service/plugins/worker/create.js:4:16)\n    at Module._compile (internal/modules/cjs/loader.js:999:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)\n    at Module.load (internal/modules/cjs/loader.js:863:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:708:14)\n    at Module.require (internal/modules/cjs/loader.js:887:19)\n    at require (internal/modules/cjs/helpers.js:74:18)","timestamp":"2022-10-25T00:45:29.092Z"}
```

The cause is that a character string is entered as an argument that should be a number, so parseInt solves the problem.
According to the docs, the other arguments should also be numeric, so this PR fixes them too.
https://github.com/actionhero/node-resque#multi-worker

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
queue-service starts even when WORKER_MAX_TASK_PROCESSORS is used.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
This issue occurs the version after the PR is merged.
https://github.com/screwdriver-cd/queue-service/pull/57

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
