### PR TITLE
Add queue locks in addition to job lock

### DIFF
--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -523,7 +523,7 @@ async function init(executor) {
                         };
                     }
 
-                    return await startPeriodic(executor, fullConfig);
+                    await startPeriodic(executor, fullConfig);
                 } catch (err) {
                     logger.error(`err in startDelayed job: ${err}`);
                     throw err;
@@ -531,6 +531,9 @@ async function init(executor) {
             },
             plugins: [Plugins.Retry, Plugins.JobLock, Plugins.DelayQueueLock, Plugins.QueueLock],
             pluginOptions: {
+                JobLock: {
+                    reEnqueue: false
+                },
                 Retry: {
                     retryLimit: RETRY_LIMIT,
                     retryDelay: RETRY_DELAY

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -529,11 +529,8 @@ async function init(executor) {
                     throw err;
                 }
             },
-            plugins: [Plugins.Retry, Plugins.JobLock],
+            plugins: [Plugins.Retry, Plugins.JobLock, Plugins.DelayQueueLock, Plugins.QueueLock],
             pluginOptions: {
-                JobLock: {
-                    reEnqueue: false
-                },
                 Retry: {
                     retryLimit: RETRY_LIMIT,
                     retryDelay: RETRY_DELAY


### PR DESCRIPTION
## Context

Sometimes scheduler is enqueuing same job multiple time which causes a periodic job to execute twice. 

## Objective

Add delayedqueue & queue lock to prevent same job from getting enqueued twice.
Previous PR https://github.com/screwdriver-cd/queue-service/pull/65 added joblock, however logs suggests same job was picked at different times even with the fix.

<img width="1433" alt="Screenshot 2023-05-10 at 8 59 13 AM" src="https://github.com/screwdriver-cd/queue-service/assets/193126/cd8eab7d-bbee-4486-b239-14732fd61785">


## References

https://github.com/screwdriver-cd/screwdriver/issues/2311
https://github.com/screwdriver-cd/queue-service/pull/65

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
