### PR TITLE
fix(2897): Fix periodic build scheduling

### DIFF
--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -232,9 +232,9 @@ async function startPeriodic(executor, config) {
             // eslint-disable-next-line max-len
             if (err && err.message !== 'Job already enqueued at this time with same arguments') {
                 shouldRetry = true;
-                logger.warn(`duplicate build: failed to enqueue for job ${job.id}: ${err}`);
-            } else {
                 logger.error(`failed to enqueue for job ${job.id}: ${err}`);
+            } else {
+                logger.warn(`duplicate build: failed to enqueue for job ${job.id}: ${err}`);
             }
         }
 

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -223,7 +223,7 @@ async function startPeriodic(executor, config) {
         let shouldRetry = false;
         const nextDate = new Date(next);
 
-        logger.info(`Enqueued periodic job ${jobId} to be executed at ${nextDate}`);
+        logger.info(`Enqueued periodic job ${job.id} to be executed at ${nextDate}`);
 
         try {
             await executor.queue.enqueueAt(next, executor.periodicBuildQueue, 'startDelayed', [{ jobId: job.id }]);
@@ -233,8 +233,6 @@ async function startPeriodic(executor, config) {
             if (err && err.message !== 'Job already enqueued at this time with same arguments') {
                 shouldRetry = true;
                 logger.warn(`duplicate build: failed to enqueue for job ${job.id}: ${err}`);
-            } else {
-                logger.error(`failed to enqueue for job ${job.id}: ${err}`);
             }
         }
 

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -221,6 +221,9 @@ async function startPeriodic(executor, config) {
 
         // Note: arguments to enqueueAt are [timestamp, queue name, job name, array of args]
         let shouldRetry = false;
+        const nextDate = new Date(next);
+
+        logger.info(`Enqueued periodic job ${jobId} to be executed at ${nextDate}`);
 
         try {
             await executor.queue.enqueueAt(next, executor.periodicBuildQueue, 'startDelayed', [{ jobId: job.id }]);
@@ -230,8 +233,6 @@ async function startPeriodic(executor, config) {
             if (err && err.message !== 'Job already enqueued at this time with same arguments') {
                 shouldRetry = true;
                 logger.warn(`duplicate build: failed to enqueue for job ${job.id}: ${err}`);
-            } else {
-                logger.error(`failed to enqueue for job ${job.id}: ${err}`);
             }
         }
 

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -233,6 +233,8 @@ async function startPeriodic(executor, config) {
             if (err && err.message !== 'Job already enqueued at this time with same arguments') {
                 shouldRetry = true;
                 logger.warn(`duplicate build: failed to enqueue for job ${job.id}: ${err}`);
+            } else {
+                logger.error(`failed to enqueue for job ${job.id}: ${err}`);
             }
         }
 

--- a/plugins/queue/utils/cron.js
+++ b/plugins/queue/utils/cron.js
@@ -107,7 +107,14 @@ const transformCron = (cronExp, jobId) => {
  * @return {Number}         Epoch timestamp (time of next execution).
  */
 const nextExecution = cronExp => {
-    const interval = parseExpression(cronExp);
+    // Scheduled jobs may run a little ahead of schedule.
+    // The next job to be executed is delayed so that it will be at the next timing even in that case.
+    let date = Date.now();
+    date.setMinutes(date.getMinutes() + 5);
+    const options = {
+        currentDate: date
+    };
+    const interval = parseExpression(cronExp, options);
 
     return interval.next().getTime();
 };

--- a/plugins/queue/utils/cron.js
+++ b/plugins/queue/utils/cron.js
@@ -109,7 +109,7 @@ const transformCron = (cronExp, jobId) => {
 const nextExecution = cronExp => {
     // Scheduled jobs may run a little ahead of schedule.
     // The next job to be executed is delayed so that it will be at the next timing even in that case.
-    const date = Date.now();
+    const date = new Date();
 
     date.setMinutes(date.getMinutes() + 5);
     const options = {

--- a/plugins/queue/utils/cron.js
+++ b/plugins/queue/utils/cron.js
@@ -110,7 +110,7 @@ const nextExecution = cronExp => {
     // Scheduled jobs may run a little ahead of schedule.
     // The next job to be executed is delayed so that it will be at the next timing even in that case.
     const date = Date.now();
-    
+
     date.setMinutes(date.getMinutes() + 5);
     const options = {
         currentDate: date

--- a/plugins/queue/utils/cron.js
+++ b/plugins/queue/utils/cron.js
@@ -109,7 +109,8 @@ const transformCron = (cronExp, jobId) => {
 const nextExecution = cronExp => {
     // Scheduled jobs may run a little ahead of schedule.
     // The next job to be executed is delayed so that it will be at the next timing even in that case.
-    let date = Date.now();
+    const date = Date.now();
+    
     date.setMinutes(date.getMinutes() + 5);
     const options = {
         currentDate: date

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -155,6 +155,7 @@ describe('scheduler test', () => {
         };
         winstonMock = {
             info: sinon.stub(),
+            warn: sinon.stub(),
             error: sinon.stub()
         };
         configMock = {

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -3,12 +3,12 @@
 /* eslint-disable max-lines-per-function */
 /* eslint-disable no-underscore-dangle */
 
-const chai = require('chai');
 const util = require('util');
+const { EventEmitter } = require('events');
+const chai = require('chai');
 const { assert } = chai;
 const mockery = require('mockery');
 const sinon = require('sinon');
-const { EventEmitter } = require('events');
 const defaultConfig = require('config');
 const testConnection = require('../../data/testConnection.json');
 const testConfig = require('../../data/fullConfig.json');

--- a/test/plugins/queue/utils/cron.test.js
+++ b/test/plugins/queue/utils/cron.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
+const sinon = require('sinon');
 const hash = require('string-hash');
 const cron = require('../../../../plugins/queue/utils/cron');
 
@@ -53,5 +54,27 @@ describe('cron', () => {
             Error,
             'H(99-100) has an invalid range, expected range 0-23'
         );
+    });
+
+    it('should return the next timing', () => {
+        const now = new Date('2020-01-01 09:01:00');
+        const next = new Date('2020-01-01 10:00:00');
+        const clock = sinon.useFakeTimers(now.getTime());
+
+        const cronExp = '0 * * * *';
+
+        assert.deepEqual(cron.next(cronExp), next.getTime());
+        clock.restore();
+    });
+
+    it('should return the next next timing in case the timing is a little early', () => {
+        const now = new Date('2020-01-01 08:59:50');
+        const next = new Date('2020-01-01 10:00:00');
+        const clock = sinon.useFakeTimers(now.getTime());
+
+        const cronExp = '0 * * * *';
+
+        assert.deepEqual(cron.next(cronExp), next.getTime());
+        clock.restore();
     });
 });

--- a/test/plugins/worker/worker.test.js
+++ b/test/plugins/worker/worker.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const { assert } = require('chai');
 const { EventEmitter } = require('events');
+const util = require('util');
+const { assert } = require('chai');
 const mockery = require('mockery');
 const sinon = require('sinon');
-const util = require('util');
 
 sinon.assert.expose(assert, { prefix: '' });
 


### PR DESCRIPTION
## Context
Currently periodic build sometimes stops working. This is because it is failing to queue the next periodic job.
Periodic jobs may run earlier than scheduled. In this case, the next job will be scheduled at the time when the previous job was scheduled. If this happens, the next job is removed by `JobLock`.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
The scheduled time of the next job is calculated based not on the current time but on a time slightly later than the current time. Then, even if a job is executed a little earlier, the next job is executed at the next timing.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2897
https://github.com/harrisiirak/cron-parser#readme
https://www.npmjs.com/package/node-resque
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
