### PR TITLE
Revert "fix(3055): remove k8s-vm dependence"

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -89,6 +89,71 @@ executor:
             # in milliseconds
             retryDelay: REQUEST_RETRYDELAY
             maxAttempts: REQUEST_MAXATTEMPTS
+    k8s-vm:
+      options:
+        # Configuration of Docker
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: K8S_HOST
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
+            privileged: K8S_SECURITYCONTEXT_PRIVILEGED
+            # The jwt token used for authenticating kubernetes requests
+            token: K8S_TOKEN
+            jobsNamespace: K8S_JOBS_NAMESPACE
+            baseImage: K8S_BASE_IMAGE
+            # Resources for build pod
+            resources:
+                # Number of cpu cores
+                cpu:
+                    micro: K8S_CPU_MICRO
+                    low: K8S_CPU_LOW
+                    high: K8S_CPU_HIGH
+                    turbo: K8S_CPU_TURBO
+                    # upper bound for user custom cpu
+                    max: K8S_CPU_MAX
+                # Memory in GB
+                memory:
+                    micro: K8S_MEMORY_MICRO
+                    low: K8S_MEMORY_LOW
+                    high: K8S_MEMORY_HIGH
+                    turbo: K8S_MEMORY_TURBO
+                    # upper bound for user custom memory
+                    max: K8S_MEMORY_MAX
+                disk:
+                  space: K8S_DISK_LABEL
+                  speed: K8S_DISK_SPEED_LABEL
+            # Default build timeout for all builds in this cluster
+            buildTimeout: K8S_VM_BUILD_TIMEOUT
+            # Default max build timeout
+            maxBuildTimeout: K8S_VM_MAX_BUILD_TIMEOUT
+            # k8s node selectors for approprate build pod scheduling.
+            # Value is Object of format { label: 'value' } See
+            # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
+            # Eg: { dedicated: 'screwdriver' } to schedule pods on nodes having
+            # label-value of dedicated=screwdriver
+            nodeSelectors:
+              __name: K8S_VM_NODE_SELECTORS
+              __format: json
+            # k8s preferred node selectors for build pod scheduling
+            # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+            preferredNodeSelectors:
+              __name: K8S_VM_PREFERRED_NODE_SELECTORS
+              __format: json
+        # Launcher image to use
+        launchImage: LAUNCH_IMAGE
+        # Launcher container tag to use
+        launchVersion: LAUNCH_VERSION
+        # Prefix to the container
+        prefix: EXECUTOR_PREFIX
+        # Circuit breaker config
+        fusebox:
+            breaker:
+                # in milliseconds
+                timeout: CIRCUIT_TIMEOUT
+        requestretry:
+            # in milliseconds
+            retryDelay: REQUEST_RETRYDELAY
+            maxAttempts: REQUEST_MAXATTEMPTS
     jenkins:
       options:
         jenkins:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -74,6 +74,53 @@ executor:
         # in milliseconds
         retryDelay: 3000
         maxAttempts: 5
+  k8s-vm:
+    options:
+      # Configuration of Docker
+      kubernetes:
+        # The host or IP of the kubernetes cluster
+        host: kubernetes.default
+        # Privileged mode, default restricted, set to true for trusted container runtime use-case
+        privileged: false
+        # Resources for build pod
+        resources:
+          cpu:
+            # Number of cpu cores
+            micro: 1
+            low: 2
+            high: 6
+            turbo: 12
+            # upper bound for user custom cpu
+            max: 12
+          memory:
+            # Memory in GB
+            micro: 1
+            low: 2
+            high: 12
+            turbo: 16
+            # upper bound for user custom memory
+            max: 16
+        # Default build timeout for all builds in this cluster
+        buildTimeout: 90
+        # Default max build timeout
+        maxBuildTimeout: 120
+        # k8s node selectors for approprate pod scheduling
+        nodeSelectors: {}
+        preferredNodeSelectors: {}
+      # Launcher image to use
+      launchImage: screwdrivercd/launcher
+      # Launcher container tag to use
+      launchVersion: stable
+      # Circuit breaker config
+      fusebox:
+        breaker:
+          # in milliseconds
+          timeout: 10000
+      # requestretry configs
+      requestretry:
+        # in milliseconds
+        retryDelay: 3000
+        maxAttempts: 5
 
 httpd:
   # Port to listen on

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "screwdriver-executor-docker": "^7.0.0",
     "screwdriver-executor-jenkins": "^7.0.0",
     "screwdriver-executor-k8s": "^16.0.0",
+    "screwdriver-executor-k8s-vm": "^5.0.0",
     "screwdriver-executor-router": "^4.0.0",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-request": "^2.0.1",

--- a/test/data/executorConfig.json
+++ b/test/data/executorConfig.json
@@ -1,5 +1,5 @@
 {
-    "plugin": "k8s-test",
+    "plugin": "k8s-vm",
     "k8s": {
         "options": {
             "kubernetes": {
@@ -43,7 +43,7 @@
             }
         }
     },
-    "k8s-test": {
+    "k8s-vm": {
         "options": {
             "kubernetes": {
                 "host": "kubernetes.default",


### PR DESCRIPTION
Reverts screwdriver-cd/queue-service#74

We are still seeing some use cases of `k8s-vm` so we cannot really remove this dependency right now.