### PR TITLE
feat(3209): Skip execution of virtual job and mark it as SUCCESS

### DIFF
--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -21,6 +21,16 @@ const TEMPORAL_UNZIP_TOKEN_TIMEOUT = 2 * 60; // 2 hours in minutes
 const BLOCKED_BY_SAME_JOB_WAIT_TIME = 5;
 
 /**
+ * Checks whether the job associated with the build is virtual or not
+ * @method isVirtualJob
+ * @param {Object} annotations           Job Annotations
+ * @return {Boolean}
+ */
+function isVirtualJob(annotations) {
+    return annotations && annotations['screwdriver.cd/virtualJob'];
+}
+
+/**
  * Posts a new build event to the API
  * @method postBuildEvent
  * @param {Object} eventConfig           Configuration
@@ -300,7 +310,8 @@ async function start(executor, config) {
         apiUri,
         pipeline,
         isPR,
-        prParentJobId
+        prParentJobId,
+        annotations
     } = config;
     const forceStart = /\[(force start)\]/.test(causeMessage);
 
@@ -411,48 +422,75 @@ async function start(executor, config) {
             throw value.error;
         }
 
-        const token = executor.tokenGen(Object.assign(tokenConfig, { scope: ['temporal'] }), TEMPORAL_TOKEN_TIMEOUT);
+        if (isVirtualJob(annotations)) {
+            // Bypass execution of the build if the job is virtual
+            const payload = {
+                status: 'SUCCESS',
+                statusMessage: 'Skipped execution of the virtual job'
+            };
 
-        // set the start time in the queue
-        Object.assign(config, { token });
-        // Store the config in redis
-        await executor.redisBreaker.runCommand('hset', executor.buildConfigTable, buildId, JSON.stringify(config));
-
-        const blockedBySameJob = reach(config, 'annotations>screwdriver.cd/blockedBySameJob', {
-            separator: '>',
-            default: true
-        });
-        const blockedBySameJobWaitTime = reach(config, 'annotations>screwdriver.cd/blockedBySameJobWaitTime', {
-            separator: '>',
-            default: BLOCKED_BY_SAME_JOB_WAIT_TIME
-        });
-
-        // Note: arguments to enqueue are [queue name, job name, array of args]
-        enq = await executor.queueBreaker.runCommand('enqueue', executor.buildQueue, 'start', [
-            {
-                buildId,
-                jobId,
-                blockedBy: blockedBy.toString(),
-                blockedBySameJob,
-                blockedBySameJobWaitTime
-            }
-        ]);
-        if (buildStats) {
             await helper
                 .updateBuild(
                     {
                         buildId,
                         token: buildToken,
                         apiUri,
-                        payload: { stats: build.stats, status: 'QUEUED' }
+                        payload
                     },
                     helper.requestRetryStrategy
                 )
                 .catch(err => {
-                    logger.error(`Failed to update build status for build ${buildId}: ${err}`);
+                    logger.error(`virtualBuilds: failed to update build status for build ${buildId}: ${err}`);
 
                     throw err;
                 });
+        } else {
+            const token = executor.tokenGen(
+                Object.assign(tokenConfig, { scope: ['temporal'] }),
+                TEMPORAL_TOKEN_TIMEOUT
+            );
+
+            // set the start time in the queue
+            Object.assign(config, { token });
+            // Store the config in redis
+            await executor.redisBreaker.runCommand('hset', executor.buildConfigTable, buildId, JSON.stringify(config));
+
+            const blockedBySameJob = reach(config, 'annotations>screwdriver.cd/blockedBySameJob', {
+                separator: '>',
+                default: true
+            });
+            const blockedBySameJobWaitTime = reach(config, 'annotations>screwdriver.cd/blockedBySameJobWaitTime', {
+                separator: '>',
+                default: BLOCKED_BY_SAME_JOB_WAIT_TIME
+            });
+
+            // Note: arguments to enqueue are [queue name, job name, array of args]
+            enq = await executor.queueBreaker.runCommand('enqueue', executor.buildQueue, 'start', [
+                {
+                    buildId,
+                    jobId,
+                    blockedBy: blockedBy.toString(),
+                    blockedBySameJob,
+                    blockedBySameJobWaitTime
+                }
+            ]);
+            if (buildStats) {
+                await helper
+                    .updateBuild(
+                        {
+                            buildId,
+                            token: buildToken,
+                            apiUri,
+                            payload: { stats: build.stats, status: 'QUEUED' }
+                        },
+                        helper.requestRetryStrategy
+                    )
+                    .catch(err => {
+                        logger.error(`Failed to update build status for build ${buildId}: ${err}`);
+
+                        throw err;
+                    });
+            }
         }
     }
 


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/screwdriver/issues/3027
A job can be marked as virtual by adding the annotation `screwdriver.cd/virtualJob: true`. Such jobs should not be executed.

## Objective

Builds added to the queue for virtual jobs should skip the execution.
Status of builds of such jobs should be updated to "SUCCESS".

## References

https://github.com/screwdriver-cd/screwdriver/issues/3209

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
