### PR TITLE
feat(3211): Set build status message type while skipping execution of virtual job

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node-resque": "^9.2.0",
     "redlock": "^4.2.0",
     "screwdriver-aws-producer-service": "^2.0.0",
-    "screwdriver-data-schema": "^24.0.0",
+    "screwdriver-data-schema": "^24.1.0",
     "screwdriver-executor-docker": "^7.0.0",
     "screwdriver-executor-jenkins": "^7.0.0",
     "screwdriver-executor-k8s": "^16.0.0",

--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -428,7 +428,8 @@ async function start(executor, config) {
             // Bypass execution of the build if the job is virtual
             buildUpdatePayload = {
                 status: 'SUCCESS',
-                statusMessage: 'Skipped execution of the virtual job'
+                statusMessage: 'Skipped execution of the virtual job',
+                statusMessageType: 'INFO'
             };
         } else {
             const token = executor.tokenGen(

--- a/test/plugins/queue/scheduler.test.js
+++ b/test/plugins/queue/scheduler.test.js
@@ -797,7 +797,11 @@ describe('scheduler test', () => {
                         buildId,
                         token: 'buildToken',
                         apiUri: 'http://api.com',
-                        payload: { status: 'SUCCESS', statusMessage: 'Skipped execution of the virtual job' }
+                        payload: {
+                            status: 'SUCCESS',
+                            statusMessage: 'Skipped execution of the virtual job',
+                            statusMessageType: 'INFO'
+                        }
                     },
                     helperMock.requestRetryStrategy
                 );


### PR DESCRIPTION
## Context

All the build status message are currently treated/visualized as warning in the UI. We need a mechanism to distinguish the messages based on severity.

Status message that is being set while skipping execution of virtual job should visualized as a information.

## Objective

Set status message type to `INFO`.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3211

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
