### PR TITLE
feat: add payload size validation to queue POST route

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -18,6 +18,6 @@ const authConfig = config.get('auth');
 server({
     httpd: httpdConfig,
     ecosystem,
-    queueConfig,
+    queue: queueConfig,
     auth: authConfig
 });

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -239,6 +239,7 @@ queue:
   prefix: REDIS_QUEUE_PREFIX
   # whether or not to retrieve from redis that the data needed to start periodic builds
   periodicBuildTableEnabled: PERIODIC_BUILD_TABLE_ENABLED
+  queueMaxPayloadSize: QUEUE_MAX_PAYLOAD_SIZE
 
 plugins:
     blockedBy:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -167,6 +167,8 @@ queue:
   prefix: ""
   # whether or not to retrieve from redis that the data needed to start periodic builds
   periodicBuildTableEnabled: true
+  # max payload size in bytes, default to 10MB
+  queueMaxPayloadSize: 10485760
 
 plugins:
   blockedBy:

--- a/lib/server.js
+++ b/lib/server.js
@@ -59,7 +59,7 @@ module.exports = async config => {
         // Setup Executor
         const executor = new ExecutorQueue({
             ecosystem: hoek.clone(config.ecosystem),
-            ...config.queueConfig
+            ...config.queue
         });
 
         server.app = {

--- a/plugins/queue/index.js
+++ b/plugins/queue/index.js
@@ -7,7 +7,7 @@ const scheduler = require('./scheduler');
 
 const queuePlugin = {
     name: 'queue',
-    async register(server) {
+    async register(server, options) {
         /**
          * Exposes an init function to begin the scheduler process
          * @method init
@@ -28,7 +28,7 @@ const queuePlugin = {
             return scheduler.cleanUp(executor);
         });
 
-        server.route([putRoute(), deleteRoute(), statsRoute()]);
+        server.route([putRoute(options), deleteRoute(), statsRoute()]);
     }
 };
 

--- a/plugins/queue/put.js
+++ b/plugins/queue/put.js
@@ -3,7 +3,7 @@
 const logger = require('screwdriver-logger');
 const scheduler = require('./scheduler');
 
-module.exports = () => ({
+module.exports = options => ({
     method: 'POST',
     path: '/queue/message',
     config: {
@@ -14,8 +14,14 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['sdapi']
         },
+        payload: {
+            maxBytes: parseInt(options.queueMaxPayloadSize, 10) || 5242880, // 5MB default
+            parse: true,
+            output: 'data'
+        },
         handler: async (request, h) => {
             try {
+                console.log('options', options);
                 const executor = request.server.app.executorQueue;
 
                 const { type } = request.query;

--- a/plugins/queue/put.js
+++ b/plugins/queue/put.js
@@ -21,7 +21,6 @@ module.exports = options => ({
         },
         handler: async (request, h) => {
             try {
-                console.log('options', options);
                 const executor = request.server.app.executorQueue;
 
                 const { type } = request.query;

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -14,7 +14,7 @@ describe('server case', () => {
     };
     const config = {
         ecosystem,
-        queueConfig: {
+        queue: {
             redisConnection: {
                 port: 4321,
                 host: '127.0.0.0',

--- a/test/plugins/queue/index.test.js
+++ b/test/plugins/queue/index.test.js
@@ -87,7 +87,8 @@ describe('queue plugin test', () => {
         await server.register({
             plugin,
             options: {
-                name: 'queue'
+                name: 'queue',
+                queueMaxPayloadSize: 5242880
             },
             routes: {
                 prefix: '/v1'
@@ -273,6 +274,14 @@ describe('queue plugin test', () => {
 
             assert.equal(reply.statusCode, 200);
             assert.calledOnce(schedulerMock.queueWebhook);
+        });
+
+        // check max payload validation
+        it('returns 413 when payload exceeds maxBytes', async () => {
+            options.payload = Buffer.alloc(6 * 1024 * 1024, 'a'); // 6MB
+            const reply = await server.inject(options);
+
+            assert.equal(reply.statusCode, 413);
         });
     });
 });

--- a/test/plugins/queue/stats.test.js
+++ b/test/plugins/queue/stats.test.js
@@ -58,7 +58,8 @@ describe('queue plugin test', () => {
         await server.register({
             plugin,
             options: {
-                name: 'queue'
+                name: 'queue',
+                queueMaxPayloadSize: 5242880
             },
             routes: {
                 prefix: '/v1'


### PR DESCRIPTION
## Context

Queue message POST route does not have payload validation control and defaults to hapi default value of 1MB

## Objective

This PR makes the payload validation configurable

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
