### PR TITLE
fix: remove blockedBy.toString() and require('cjson')

### DIFF
--- a/plugins/queue/scheduler.js
+++ b/plugins/queue/scheduler.js
@@ -493,7 +493,7 @@ async function start(executor, config) {
                     {
                         buildId,
                         jobId,
-                        blockedBy: blockedBy.toString(),
+                        blockedBy,
                         blockedBySameJob,
                         blockedBySameJobWaitTime
                     }
@@ -758,13 +758,7 @@ async function stopTimer(executor, config) {
 async function stop(executor, config) {
     await executor.connect();
 
-    const { buildId, jobId } = config; // in case config contains something else
-
-    let blockedBy;
-
-    if (config.blockedBy !== undefined) {
-        blockedBy = config.blockedBy.toString();
-    }
+    const { buildId, jobId, blockedBy } = config; // in case config contains something else
 
     const numDeleted = await executor.queueBreaker.runCommand('del', executor.buildQueue, 'start', [
         {

--- a/plugins/worker/lib/lua/stopBuild.lua
+++ b/plugins/worker/lib/lua/stopBuild.lua
@@ -25,8 +25,6 @@
     }
 ]]
 
--- Load cjson for JSON encoding/decoding
-local cjson = require("cjson")
 
 -- Parse arguments
 local buildId = ARGV[1]


### PR DESCRIPTION
## Context

Fix bugs with stop build 

## Objective

This commit fixes two critical bugs causing build validation and cleanup failures:
   - blockedBy was being converted from array [142288] to string "142288"
   - stopBuild.lua had require("cjson") which is not needed

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
