### PR TITLE
fix: upgrade js-yaml to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hapi-auth-jwt2": "^10.2.0",
     "ioredis": "^5.2.3",
     "joi": "^17.7.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^5.2.3",
     "jsonwebtoken": "^9.0.0",
     "node-resque": "^9.2.0",
     "redlock": "^4.2.0",


### PR DESCRIPTION
## Context

Snyk detected a vulnerability in js-yaml dependency paths.

## Objective

Upgrade js-yaml to v5.2.3.

Merge this PR after executor-k8s #214 is merged and released.

## References

- https://github.com/screwdriver-cd/screwdriver/issues/3510
- https://github.com/screwdriver-cd/executor-k8s/pull/214